### PR TITLE
fix: propagate exit code from REPL to process exit status

### DIFF
--- a/src/exit.rs
+++ b/src/exit.rs
@@ -41,6 +41,12 @@ impl From<ExitCode> for i32 {
     }
 }
 
+impl From<ExitCode> for std::process::ExitCode {
+    fn from(val: ExitCode) -> Self {
+        std::process::ExitCode::from(val.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,6 @@ pub use shell::Shell;
 /// let mut shell = Shell::builder().with_io(io);
 /// let result = shell.run();
 /// ```
-pub fn run() -> anyhow::Result<()> {
+pub fn run() -> anyhow::Result<exit::ExitCode> {
     Shell::<crate::io::StandardIo>::builder().with_std_io().run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
-fn main() -> anyhow::Result<()> {
-    ferrish::run()
+fn main() {
+    match ferrish::run() {
+        Ok(code) => std::process::exit(code.as_i32()),
+        Err(e) => {
+            eprintln!("ferrish: {e:#}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,4 @@
-fn main() {
-    match ferrish::run() {
-        Ok(code) => std::process::exit(code.as_i32()),
-        Err(e) => {
-            eprintln!("ferrish: {e:#}");
-            std::process::exit(1);
-        }
-    }
+fn main() -> anyhow::Result<std::process::ExitCode> {
+    let code = ferrish::run()?;
+    Ok(code.into())
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -49,7 +49,7 @@ impl<IO: ShellIo> Shell<IO> {
         self.io.borrow_mut()
     }
 
-    pub fn run(&mut self) -> anyhow::Result<()> {
+    pub fn run(&mut self) -> anyhow::Result<ExitCode> {
         loop {
             {
                 let mut io = self.io.borrow_mut();
@@ -71,10 +71,7 @@ impl<IO: ShellIo> Shell<IO> {
 
             let (command, args) = parser::parse(buffer);
             match self.execute_command(command.clone(), args) {
-                Ok(Some(_exit_code)) => {
-                    // TODO: set exit code in caller env
-                    break;
-                }
+                Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
@@ -87,8 +84,6 @@ impl<IO: ShellIo> Shell<IO> {
                 }
             }
         }
-
-        Ok(())
     }
 
     pub fn run_script(&mut self, script: &[&str]) -> anyhow::Result<ExitCode> {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -61,7 +61,7 @@ impl<IO: ShellIo> Shell<IO> {
             let mut buffer = Vec::<u8>::new();
             let bytes = self.io.borrow_mut().read_line(&mut buffer)?;
             if bytes == 0 {
-                continue;
+                return Ok(ExitCode::SUCCESS);
             }
 
             let buffer = buffer.trim_ascii();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -98,7 +98,6 @@ impl<IO: ShellIo> Shell<IO> {
 
             let (command, args) = parser::parse(buffer);
             if let Some(exit_code) = self.execute_command(command, args)? {
-                // TODO: set exit code in caller env instead of returning
                 return Ok(exit_code);
             }
         }

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -101,11 +101,13 @@ impl ShellTest {
         let output = String::from_utf8_lossy(shell.io().output()).to_string();
         let error = String::from_utf8_lossy(shell.io().error()).to_string();
 
-        run_result.unwrap_or_else(|err| {
-            panic!("shell.run() failed: {err}\nstdout:\n{output}\nstderr:\n{error}");
-        });
+        let exit_code = run_result
+            .unwrap_or_else(|err| {
+                panic!("shell.run() failed: {err}\nstdout:\n{output}\nstderr:\n{error}");
+            })
+            .0;
 
-        TestResult { output, error, home_dir: self.home_dir }
+        TestResult { output, error, home_dir: self.home_dir, exit_code }
         // self drops here — temp_dir is cleaned up
     }
 }
@@ -116,6 +118,7 @@ pub struct TestResult {
     error: String,
     #[allow(dead_code)]
     home_dir: Option<PathBuf>,
+    exit_code: u8,
 }
 
 impl TestResult {
@@ -126,6 +129,11 @@ impl TestResult {
     #[allow(dead_code)]
     pub fn error(&self) -> &str {
         &self.error
+    }
+
+    #[allow(dead_code)]
+    pub fn exit_code(&self) -> u8 {
+        self.exit_code
     }
 
     #[allow(dead_code)]

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -118,6 +118,7 @@ pub struct TestResult {
     error: String,
     #[allow(dead_code)]
     home_dir: Option<PathBuf>,
+    #[allow(dead_code)]
     exit_code: u8,
 }
 

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -40,6 +40,28 @@ fn test_repl_sequential_commands() {
 }
 
 // ============================================================================
+// Exit Code Propagation Tests
+// ============================================================================
+
+#[test]
+fn test_exit_zero_propagates() {
+    let result = ShellTest::new().script("exit 0").run();
+    assert_eq!(result.exit_code(), 0);
+}
+
+#[test]
+fn test_exit_nonzero_propagates() {
+    let result = ShellTest::new().script("exit 1").run();
+    assert_eq!(result.exit_code(), 1);
+}
+
+#[test]
+fn test_exit_arbitrary_code_propagates() {
+    let result = ShellTest::new().script("exit 42").run();
+    assert_eq!(result.exit_code(), 42);
+}
+
+// ============================================================================
 // Error Handling and Recovery Tests
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- `Shell::run()` return type changed from `anyhow::Result<()>` to `anyhow::Result<ExitCode>`
- `lib::run()` propagates the new return type
- `main()` returns `anyhow::Result<std::process::ExitCode>`; the `?` operator propagates fatal errors with full anyhow context, and the `Termination` impl exits the process with the shell's actual exit code
- Added `From<ExitCode> for std::process::ExitCode` in `exit.rs` to keep `main` clean
- Fixed stdin EOF handling: `run()` now returns `Ok(ExitCode::SUCCESS)` on a 0-byte read instead of spinning the REPL loop
- Resolves #16

## Test plan

- [ ] `test_exit_zero_propagates` — `exit 0` returns `ExitCode(0)`
- [ ] `test_exit_nonzero_propagates` — `exit 1` returns `ExitCode(1)`
- [ ] `test_exit_arbitrary_code_propagates` — `exit 42` returns `ExitCode(42)`
- [ ] `TestResult` in the harness now exposes `exit_code()` for future tests
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)