### PR TITLE
docs: add CONTRIBUTING.md and update README contributing section

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Prefer integration tests via the `ShellTest` harness in `tests/harness.rs` for a
 
 ## Lint
 
-`cargo clippy -- -D warnings` is enforced by CI. No warnings are allowed. Fix warnings before opening a PR rather than suppressing them with `#[allow(...)]` unless suppression is genuinely justified.
+`cargo clippy --all-targets --all-features -- -D warnings` is enforced by CI. No warnings are allowed. Fix warnings before opening a PR rather than suppressing them with `#[allow(...)]` unless suppression is genuinely justified.
 
 ## Core Principles
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to ferrish
+
+## Branch Naming
+
+Branches must follow the pattern `type/issue-N-short-description`:
+
+- `fix/issue-52-readme-banners`
+- `refactor/issue-12-type-command`
+- `feat/issue-7-pipeline-support`
+
+Valid types: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`.
+
+## PR Workflow
+
+- Squash merge only; each PR addresses one concern.
+- Reference the issue in the PR body with `closes #N`.
+- Keep diffs minimal and focused. Avoid unrelated cleanup in the same PR.
+
+## Tests
+
+All changes must pass:
+
+```bash
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Prefer integration tests via the `ShellTest` harness in `tests/harness.rs` for anything user-visible. Unit tests are appropriate for internal logic that is difficult to exercise from the outside.
+
+## Lint
+
+`cargo clippy -- -D warnings` is enforced by CI. No warnings are allowed. Fix warnings before opening a PR rather than suppressing them with `#[allow(...)]` unless suppression is genuinely justified.
+
+## Core Principles
+
+These principles guide all design and implementation decisions:
+
+- **Correctness over performance** — when a trade-off exists, correctness wins.
+- **Safety by default** — avoid footguns, undefined behavior, and surprising side effects.
+- **Explicit over implicit** — favor clear, readable behavior over clever but opaque magic.
+- **Predictable semantics** — the same input should always produce the same result.

--- a/README.md
+++ b/README.md
@@ -66,15 +66,7 @@ Compatibility may be explored selectively, but only when it aligns with ferrish�
 
 ## Contributing
 
-ferrish is in early development, and contributions are welcome once the core architecture begins to stabilize.
-
-If you’re interested in contributing:
-
-* Open an issue to discuss ideas before starting major work
-* Keep changes focused and aligned with ferrish’s core principles
-* Prefer clarity and correctness over clever optimizations
-
-More detailed contribution guidelines may be added as the project matures.
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for branch conventions, PR workflow, test requirements, and project principles.
 
 ---
 


### PR DESCRIPTION
## Description

Closes #11.

Adds `.github/CONTRIBUTING.md` with branching conventions, PR workflow, test and lint requirements, and project principles. Updates the README contributing section to link to it rather than duplicating content.

## Type of change
- [x] Docs

## Test checklist
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes