### PR TITLE
docs: add #[deny(missing_docs)] and doc-comments for all public APIs

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 
+/// A list of shell command arguments.
 pub type Args = Vec<Arg>;
 
-/// Represents a shell command argument
+/// Represents a shell command argument.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Arg {
+    /// A raw byte sequence argument with no further interpretation.
     Literal(Vec<u8>),
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,11 +3,14 @@ use std::fmt::Display;
 pub(crate) mod builtin;
 pub(crate) mod executable;
 
-/// Represents a shell command
+/// Represents a shell command.
 #[derive(Debug, Clone)]
 pub enum Command {
+    /// A shell built-in command (e.g. `echo`, `cd`, `exit`).
     BuiltIn(builtin::BuiltInCommand),
+    /// An external executable found on `PATH`.
     Executable(executable::ExecutableCommand),
+    /// A command token that could not be resolved to a built-in or executable.
     Unrecognized(Vec<u8>),
 }
 

--- a/src/command/builtin.rs
+++ b/src/command/builtin.rs
@@ -1,3 +1,4 @@
+/// A resolved shell built-in command ready for execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BuiltInCommand {
     name: BuiltInName,
@@ -10,22 +11,30 @@ impl std::fmt::Display for BuiltInCommand {
 }
 
 impl BuiltInCommand {
+    /// Create a new `BuiltInCommand` for the given built-in name.
     pub fn new(name: BuiltInName) -> Self {
         Self { name }
     }
 
+    /// Return the built-in name for this command.
     pub fn name(&self) -> BuiltInName {
         self.name
     }
 }
 
+/// The set of built-in commands supported by the shell.
 #[derive(strum::EnumString, strum::AsRefStr, strum::Display, Debug, Clone, Copy, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 pub enum BuiltInName {
+    /// Terminate the shell process.
     Exit,
+    /// Write arguments to standard output.
     Echo,
+    /// Report the type of a command (built-in, executable, or unknown).
     Type,
+    /// Print the current working directory.
     Pwd,
+    /// Change the current working directory.
     Cd,
 }
 

--- a/src/command/executable.rs
+++ b/src/command/executable.rs
@@ -13,12 +13,12 @@ impl std::fmt::Display for ExecutableCommand {
 }
 
 impl ExecutableCommand {
-    /// Create a new `ExecutableCommand` for the given absolute path.
+    /// Create a new `ExecutableCommand` for the given path.
     pub fn new(file_path: PathBuf) -> Self {
         Self { file_path }
     }
 
-    /// Return the absolute path to the executable.
+    /// Return the path to the executable.
     pub fn file_path(&self) -> &PathBuf {
         &self.file_path
     }

--- a/src/command/executable.rs
+++ b/src/command/executable.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+/// An external executable command located on `PATH`.
 #[derive(Debug, Clone)]
 pub struct ExecutableCommand {
     file_path: PathBuf,
@@ -12,14 +13,17 @@ impl std::fmt::Display for ExecutableCommand {
 }
 
 impl ExecutableCommand {
+    /// Create a new `ExecutableCommand` for the given absolute path.
     pub fn new(file_path: PathBuf) -> Self {
         Self { file_path }
     }
 
+    /// Return the absolute path to the executable.
     pub fn file_path(&self) -> &PathBuf {
         &self.file_path
     }
 
+    /// Return the executable name (file stem without extension).
     pub fn name(&self) -> &str {
         self.file_path
             .file_stem()

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2,9 +2,13 @@ use std::path::PathBuf;
 
 use crate::env;
 
+/// Configurable shell settings.
 pub struct ShellConfig {
+    /// The prompt string displayed before each input line.
     pub prompt: String,
+    /// Optional path to the shell history file.
     pub history_path: Option<PathBuf>,
+    /// Maximum number of history entries to retain.
     pub max_history: usize,
 }
 
@@ -18,17 +22,23 @@ impl Default for ShellConfig {
     }
 }
 
+/// Runtime context shared across all shell operations.
 pub struct ShellCtx {
+    /// The user's home directory, if known.
     pub home_dir: Option<PathBuf>,
+    /// The current working directory.
     pub cwd: PathBuf,
+    /// Shell configuration.
     pub config: ShellConfig,
 }
 
 impl ShellCtx {
+    /// Create a new context with default configuration.
     pub fn new(home_dir: Option<PathBuf>, cwd: PathBuf) -> Self {
         Self { home_dir, cwd, config: ShellConfig::default() }
     }
 
+    /// Create a new context with explicit configuration.
     pub fn with_config(home_dir: Option<PathBuf>, cwd: PathBuf, config: ShellConfig) -> Self {
         Self { home_dir, cwd, config }
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,5 +1,6 @@
 use std::{env, fs, io, path::PathBuf};
 
+/// Return the current user's home directory, if it can be determined from the environment.
 pub fn home_dir() -> Option<PathBuf> {
     #[cfg(unix)]
     {
@@ -25,10 +26,12 @@ pub fn home_dir() -> Option<PathBuf> {
     }
 }
 
+/// Return the current working directory of the process.
 pub fn current_dir() -> Result<PathBuf, io::Error> {
     env::current_dir()
 }
 
+/// Change the current working directory of the process to `path`.
 pub fn set_current_dir(path: &PathBuf) -> io::Result<()> {
     env::set_current_dir(path)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,30 +13,47 @@ pub type ShellResult<T> = anyhow::Result<T, ShellError>;
 #[derive(Error, Debug)]
 pub enum ShellError {
     // --- Command-level ---
+    /// The requested command could not be found as a built-in or on `PATH`.
     #[error("command not found")]
     CommandNotFound,
 
+    /// A required operand was not provided.
     #[error("missing operand")]
     MissingOperand,
 
     // --- File system ---
+    /// The path does not exist on the filesystem.
     #[error("no such file or directory: {arg}")]
-    FileNotFound { arg: Arg },
+    FileNotFound {
+        /// The argument that referred to the missing path.
+        arg: Arg,
+    },
 
+    /// The path exists but is a directory where a regular file was expected.
     #[error("is a directory: {arg}")]
-    IsADirectory { arg: Arg },
+    IsADirectory {
+        /// The argument that referred to the directory.
+        arg: Arg,
+    },
 
+    /// The path exists but is a regular file where a directory was expected.
     #[error("not a directory: {arg}")]
-    NotADirectory { arg: Arg },
+    NotADirectory {
+        /// The argument that referred to the non-directory path.
+        arg: Arg,
+    },
 
     // --- Process execution ---
+    /// The child process exited with a non-zero status code.
     #[error("exited with status {0}")]
     NonZeroExit(ExitStatus),
 
+    /// The shell failed to spawn or wait on the child process.
     #[error("failed to execute: {0}")]
     ExecutionFailed(#[source] std::io::Error),
 
     // --- I/O ---
+    /// An I/O error propagated from the underlying stream.
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -50,6 +50,9 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
     CommandKind::NotFound
 }
 
+/// Dispatch and execute a parsed command, returning an optional exit code.
+///
+/// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
 pub fn execute(
     command: Command,
     args: Args,

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,10 +1,14 @@
+/// A shell process exit code (0–255).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ExitCode(pub u8);
 
 impl ExitCode {
+    /// Successful exit (code 0).
     pub const SUCCESS: Self = ExitCode(0);
+    /// Generic failure exit (code 1).
     pub const FAILURE: Self = ExitCode(1);
 
+    /// Return the exit code as an `i32` for use with [`std::process::exit`].
     pub fn as_i32(&self) -> i32 {
         self.0 as i32
     }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -17,6 +17,7 @@ pub(crate) fn resolve_path(path: &PathBuf, home_dir: Option<&Path>, cwd: &Path) 
     canonicalize_path(path)
 }
 
+/// Canonicalize `path`, resolving `.` and `..` without requiring the path to exist.
 pub fn canonicalize_path(path: PathBuf) -> io::Result<PathBuf> {
     soft_canonicalize::soft_canonicalize(path)
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,15 +1,21 @@
 use std::io::{self, BufRead, BufReader, Write};
 
+/// Abstraction over shell I/O streams, enabling both real and mock implementations.
 pub trait ShellIo {
+    /// Return a mutable reference to the input reader.
     fn reader(&mut self) -> &mut dyn BufRead;
+    /// Return a mutable reference to the standard output writer.
     fn out_writer(&mut self) -> &mut dyn Write;
+    /// Return a mutable reference to the standard error writer.
     fn err_writer(&mut self) -> &mut dyn Write;
 
+    /// Read one line (up to and including `\n`) into `buffer`.
     fn read_line(&mut self, buffer: &mut Vec<u8>) -> io::Result<usize> {
         self.reader().read_until(b'\n', buffer)
     }
 }
 
+/// [`ShellIo`] implementation backed by the real `stdin`/`stdout`/`stderr` streams.
 #[derive(Debug)]
 pub struct StandardIo {
     reader: std::io::BufReader<std::io::Stdin>,
@@ -41,6 +47,7 @@ impl ShellIo for StandardIo {
     }
 }
 
+/// In-memory [`ShellIo`] implementation for use in tests.
 #[derive(Debug)]
 pub struct MockIo {
     reader: BufReader<std::io::Cursor<Vec<u8>>>,
@@ -49,6 +56,7 @@ pub struct MockIo {
 }
 
 impl MockIo {
+    /// Create a `MockIo` with the given raw bytes as stdin input.
     pub fn new(input: Vec<u8>) -> Self {
         Self {
             reader: BufReader::new(std::io::Cursor::new(input)),
@@ -57,10 +65,12 @@ impl MockIo {
         }
     }
 
+    /// Create a `MockIo` with no stdin input.
     pub fn empty() -> Self {
         Self::new(Vec::new())
     }
 
+    /// Create a `MockIo` where stdin contains each element of `lines` as a newline-terminated line.
     pub fn from_lines(lines: &[&str]) -> Self {
         let input_lines = lines
             .iter()
@@ -74,10 +84,12 @@ impl MockIo {
         Self::new(input_lines.concat())
     }
 
+    /// Return all bytes written to the stdout writer so far.
     pub fn output(&self) -> &[u8] {
         &self.output
     }
 
+    /// Return all bytes written to the stderr writer so far.
     pub fn error(&self) -> &[u8] {
         &self.error
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,27 @@
+#![deny(missing_docs)]
+//! ferrish — an early-stage shell implementation in Rust.
+
+/// Shell command argument types.
 pub mod arg;
+/// Shell command variants (built-in, executable, unrecognized).
 pub mod command;
+/// Shell context and configuration.
 pub mod ctx;
+/// Environment variable and filesystem path helpers.
 pub mod env;
+/// Error types for shell execution.
 pub mod error;
+/// Command dispatch and execution logic.
 pub mod executor;
+/// Process exit code type.
 pub mod exit;
+/// Filesystem path utilities.
 pub mod fs;
+/// I/O abstraction layer for the shell.
 pub mod io;
+/// Input parsing: splits raw bytes into a command and its arguments.
 pub mod parser;
+/// The interactive REPL shell.
 pub mod shell;
 
 pub use arg::Arg;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,7 @@ use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
 
+/// Parse a raw input line into a [`Command`] and its argument list.
 pub fn parse(buffer: &[u8]) -> (Command, Args) {
     let (command, args) = split_command_and_args(buffer);
     let command = parse_command(command);
@@ -41,6 +42,7 @@ fn split_command_and_args(buffer: &[u8]) -> (&[u8], Vec<&[u8]>) {
     (command, args)
 }
 
+/// Resolve a raw command token to a [`Command`] variant.
 pub fn parse_command(command: &[u8]) -> Command {
     if !command.is_ascii() {
         return Command::Unrecognized(command.into());
@@ -64,6 +66,7 @@ pub fn parse_command(command: &[u8]) -> Command {
     }
 }
 
+/// Parse a raw byte slice into an [`Arg`].
 pub fn parse_arg(arg: &[u8]) -> Arg {
     Arg::Literal(arg.to_vec())
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -12,11 +12,15 @@ use crate::{
     parser,
 };
 
+/// The ferrish shell REPL.
+///
+/// Generic over an I/O backend; use [`Shell::builder()`] to construct instances.
 pub struct Shell<IO: ShellIo> {
     io: RefCell<IO>,
     ctx: ShellCtx,
 }
 
+/// Type alias for a [`Shell`] backed by real stdin/stdout/stderr.
 pub type StandardShell = Shell<StandardIo>;
 
 /// Non-generic entry points: `builder()` doesn't depend on the IO type,
@@ -37,14 +41,17 @@ impl Shell<StandardIo> {
 }
 
 impl<IO: ShellIo> Shell<IO> {
+    /// Return a shared borrow of the I/O backend.
     pub fn io(&self) -> std::cell::Ref<'_, IO> {
         self.io.borrow()
     }
 
+    /// Return an exclusive borrow of the I/O backend.
     pub fn io_mut(&'_ mut self) -> std::cell::RefMut<'_, IO> {
         self.io.borrow_mut()
     }
 
+    /// Run the interactive REPL loop until `exit` is called or stdin is exhausted.
     pub fn run(&mut self) -> anyhow::Result<ExitCode> {
         loop {
             {
@@ -82,6 +89,7 @@ impl<IO: ShellIo> Shell<IO> {
         }
     }
 
+    /// Execute a sequence of command lines as a non-interactive script.
     pub fn run_script(&mut self, script: &[&str]) -> anyhow::Result<ExitCode> {
         for line in script {
             let buffer = line.as_bytes();
@@ -101,6 +109,7 @@ impl<IO: ShellIo> Shell<IO> {
         Ok(ExitCode::SUCCESS)
     }
 
+    /// Execute a single parsed command, returning an optional exit code.
     pub fn execute_command(
         &mut self,
         command: Command,
@@ -110,6 +119,7 @@ impl<IO: ShellIo> Shell<IO> {
     }
 }
 
+/// Builder for constructing a [`Shell`] with custom I/O and configuration.
 #[derive(Default)]
 pub struct ShellBuilder {
     home_dir: Option<PathBuf>,


### PR DESCRIPTION
## Description

Closes #13.

Adds `#![deny(missing_docs)]` to `src/lib.rs` and writes doc-comments for every public type, function, trait, method, and variant across all modules. `cargo doc --no-deps` now builds cleanly with no warnings or errors.

## Type of change
- [x] Docs

## Test checklist
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo doc --no-deps` builds with no warnings