### PR TITLE
docs: update CLAUDE.md — add missing modules and fix error crate reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: build
         run: cargo build --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -25,9 +23,7 @@ jobs:
     needs: [lint]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: install tarpaulin
         run: cargo install cargo-tarpaulin --version 0.31.5 --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: build release
         run: cargo build --release --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: test
         run: cargo test --verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ Input flows through: **Shell** → **Parser** → **Executor** → **BuiltIn | E
 - `src/command/executable.rs` — Wraps an external binary found on PATH
 - `src/error.rs` — `ShellError` enum; distinguishes fatal errors (process spawn/wait failures) from recoverable ones (command not found, bad path)
 - `src/io.rs` — `ShellIo` trait with `StandardIo` (real I/O) and `MockIo` (testing); this abstraction is what makes unit tests possible without spawning a process
+- `src/ctx.rs` — `ShellCtx` (runtime state: cwd, home dir, config) and `ShellConfig` (prompt, history settings)
+- `src/arg.rs` — `Arg` enum representing a parsed command argument (currently a `Literal` byte-sequence variant)
+- `src/env.rs` — PATH resolution, home directory lookup, and current-directory helpers
+- `src/exit.rs` — `ExitCode` newtype wrapping `u8`; constants `SUCCESS`/`FAILURE`, conversions to `i32` and `std::process::ExitCode`
+- `src/fs.rs` — path resolution: expands `~`, resolves relative paths against cwd, soft-canonicalizes without requiring existence
 
 ## Testing Strategy
 
@@ -50,6 +55,6 @@ The `ShellTest` builder in `harness.rs` is the primary integration test interfac
 ## Key Conventions
 
 - **File-based modules** — no `mod.rs`; each module is a standalone `.rs` file
-- **Error reporting** — miette for user-facing errors with span context; `thiserror` for internal error types
+- **Error reporting** — `thiserror` derives `Error` for `ShellError` in `src/error.rs`; `anyhow` for `Shell::run()` return type and error context
 - **REPL responsiveness** — lex/parse must complete in <100ms for typical input
 - **State** — keep shell state (env vars, working dir) centralized and test scoping/isolation explicitly


### PR DESCRIPTION
## Summary

- Expands `CLAUDE.md` Architecture section to document previously unlisted modules: `src/ctx.rs`, `src/arg.rs`, `src/env.rs`, `src/exit.rs`, and `src/fs.rs`
- Corrects the Error reporting convention: replaces incorrect `miette` reference with the actual crates used (`thiserror` + `anyhow`)
- Replaces deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` across all 4 CI workflow files (closes #65)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)