### PR TITLE
fix: validate exit argument — reject non-integer and out-of-range codes

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -74,11 +74,19 @@ fn execute_builtin(
 ) -> ShellResult<Option<ExitCode>> {
     match builtin.name() {
         BuiltInName::Exit => {
-            let code = args
-                .first()
-                .and_then(|a| a.to_string().parse::<u8>().ok())
-                .map(ExitCode)
-                .unwrap_or(ExitCode::SUCCESS);
+            let code = match args.first() {
+                None => ExitCode::SUCCESS,
+                Some(arg) => {
+                    let s = arg.to_string();
+                    match s.parse::<u8>() {
+                        Ok(n) => ExitCode(n),
+                        Err(_) => {
+                            writeln!(io.err_writer(), "exit: {}: numeric argument required", s)?;
+                            return Ok(Some(ExitCode(1)));
+                        }
+                    }
+                }
+            };
             return Ok(Some(code));
         }
         BuiltInName::Cd => execute_cd(args, io, ctx)?,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -82,7 +82,7 @@ fn execute_builtin(
                         Ok(n) => ExitCode(n),
                         Err(_) => {
                             writeln!(io.err_writer(), "exit: {}: numeric argument required", s)?;
-                            return Ok(Some(ExitCode(1)));
+                            return Ok(Some(ExitCode::FAILURE));
                         }
                     }
                 }

--- a/tests/exit_validation.rs
+++ b/tests/exit_validation.rs
@@ -18,12 +18,12 @@ fn test_exit_valid_code_exits_with_code() {
 fn test_exit_out_of_range_prints_error() {
     let result = ShellTest::new().script("exit 256").run();
     result.assert_error_contains("numeric argument required");
-    assert_ne!(result.exit_code(), 0);
+    assert_eq!(result.exit_code(), 1);
 }
 
 #[test]
 fn test_exit_non_numeric_prints_error() {
     let result = ShellTest::new().script("exit abc").run();
     result.assert_error_contains("numeric argument required");
-    assert_ne!(result.exit_code(), 0);
+    assert_eq!(result.exit_code(), 1);
 }

--- a/tests/exit_validation.rs
+++ b/tests/exit_validation.rs
@@ -1,0 +1,29 @@
+mod harness;
+
+use harness::ShellTest;
+
+#[test]
+fn test_exit_no_args_exits_zero() {
+    let result = ShellTest::new().script("exit").run();
+    assert_eq!(result.exit_code(), 0);
+}
+
+#[test]
+fn test_exit_valid_code_exits_with_code() {
+    let result = ShellTest::new().script("exit 42").run();
+    assert_eq!(result.exit_code(), 42);
+}
+
+#[test]
+fn test_exit_out_of_range_prints_error() {
+    let result = ShellTest::new().script("exit 256").run();
+    result.assert_error_contains("numeric argument required");
+    assert_ne!(result.exit_code(), 0);
+}
+
+#[test]
+fn test_exit_non_numeric_prints_error() {
+    let result = ShellTest::new().script("exit abc").run();
+    result.assert_error_contains("numeric argument required");
+    assert_ne!(result.exit_code(), 0);
+}

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -37,6 +37,7 @@ impl ShellTest {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_isolated_home(mut self) -> Self {
         let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
         let home = temp_dir.path().to_path_buf();
@@ -123,6 +124,7 @@ pub struct TestResult {
 }
 
 impl TestResult {
+    #[allow(dead_code)]
     pub fn output(&self) -> &str {
         &self.output
     }


### PR DESCRIPTION
## Summary
- `exit 256` and `exit abc` previously silently exited 0; now print error to stderr and exit 1
- `exit` (no args) and `exit N` (valid u8) unchanged
- Added integration tests for all four cases

Closes #64

## Test plan
- [ ] `cargo test` passes
- [ ] `exit 256` → stderr contains "numeric argument required", exits non-zero
- [ ] `exit abc` → same
- [ ] `exit` → exits 0 (no regression)
- [ ] `exit 42` → exits 42 (no regression)

Co-Authored-By: Claude <noreply@anthropic.com>