### PR TITLE
chore: add implement/milestone Claude Code skills

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: implement
+description: Implement a single ferrish GitHub issue end-to-end — reads the issue, creates an isolated worktree, writes code and tests following ferrish conventions, verifies with cargo test and clippy, commits, pushes, and opens a PR. Use this whenever asked to implement, fix, or work on a specific issue number. Always produces a PR URL, never a plan.
+---
+
+# Implement
+
+End-to-end implementation of a single ferrish issue. The only output that matters is a PR URL — not a plan, not a summary of what could be done.
+
+## Repo constants
+
+- Owner: `cdprice02`, Repo: `ferrish`, Base branch: `main`
+- Worktrees: `.claude/worktrees/` (gitignored)
+
+## Steps
+
+### 1. Read the issue
+
+Use `mcp__plugin_github_github__issue_read` (method: `get`) for the issue body and labels. If the issue has comments, fetch them too (`get_comments`) — they often contain scope clarifications or prior decisions that affect the implementation.
+
+If the issue is genuinely ambiguous after reading it, ask one focused question before starting. Don't guess and implement the wrong thing.
+
+### 2. Plan the branch name
+
+- Prefix by label: `fix/` for bug, `feat/` for enhancement, `chore/` for docs/infra/refactor
+- Format: `<prefix>/issue-<N>-<slug>` where slug is 2–4 kebab-case words from the title
+- Example: `feat/issue-47-help-version-flags`
+
+### 3. Create the worktree
+
+```bash
+git worktree add .claude/worktrees/issue-<N> -b <branch-name>
+```
+
+All subsequent edits and commands happen inside that worktree directory.
+
+### 4. Implement
+
+Read the relevant source files before editing — understand the existing pattern before adding to it.
+
+Key conventions:
+- File-based modules only — no `mod.rs`
+- Errors: `thiserror` derives in `src/error.rs`; `anyhow` for `Shell::run()` return type
+- All I/O goes through `ShellIo` — never print or read stdin directly; use `MockIo` in tests
+- New builtins belong in `src/command/builtin.rs`; register them in the parser
+- For anything user-visible, write an integration test using the `ShellTest` builder in `tests/harness.rs`
+- Tests that exercise internal logic belong as `#[cfg(test)]` modules in the relevant source file
+
+### 5. Verify
+
+Run both of these from the worktree root and fix anything that fails before moving on:
+
+```bash
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Do not push a failing build. Clippy warnings are CI failures — `-D warnings` is enforced.
+
+One important constraint on tests: never spawn the shell binary as a subprocess in tests. `cargo-tarpaulin` cannot trace across process boundaries, and `--follow-exec` is blocked by seccomp in GitHub Actions. Call library code directly via `ShellTest` or unit test the function in-process.
+
+### 6. Commit
+
+One conventional commit per logical change:
+
+| Prefix | When |
+|--------|------|
+| `feat:` | new capability |
+| `fix:` | bug correction |
+| `refactor:` | restructuring without behavior change |
+| `chore:` | deps, CI, tooling |
+| `docs:` | documentation only |
+
+Keep the diff minimal — don't clean up surrounding code unless the issue asks for it.
+
+### 7. Push and open PR
+
+```bash
+git push -u origin <branch-name>
+```
+
+Then open the PR via `mcp__plugin_github_github__create_pull_request`:
+- `title`: mirrors the issue title, under 70 characters
+- `body`: one-paragraph description of the approach, followed by `Closes #<N>`
+- `base`: `main`
+
+### 8. Done
+
+Return the PR URL. That's the deliverable.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -29,7 +29,7 @@ If the issue is genuinely ambiguous after reading it, ask one focused question b
 ### 3. Create the worktree
 
 ```bash
-git worktree add .claude/worktrees/issue-<N> -b <branch-name>
+git worktree add .claude/worktrees/issue-<N> -b <branch-name> origin/main
 ```
 
 All subsequent edits and commands happen inside that worktree directory.
@@ -57,7 +57,7 @@ cargo clippy --all-targets --all-features -- -D warnings
 
 Do not push a failing build. Clippy warnings are CI failures — `-D warnings` is enforced.
 
-One important constraint on tests: never spawn the shell binary as a subprocess in tests. `cargo-tarpaulin` cannot trace across process boundaries, and `--follow-exec` is blocked by seccomp in GitHub Actions. Call library code directly via `ShellTest` or unit test the function in-process.
+One important constraint on tests: prefer in-process tests for normal implementation and verification. `cargo-tarpaulin` cannot trace across process boundaries, and `--follow-exec` is blocked by seccomp in GitHub Actions, so coverage-oriented tests should call library code directly via `ShellTest` or unit test functions in-process. If an issue truly requires end-to-end validation of real shell process behavior, a separate subprocess-based test is allowed — but treat it as explicitly non-coverage verification rather than the default path.
 
 ### 6. Commit
 

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: milestone
+description: Work through all open issues in a ferrish milestone over time — lists issues, identifies dependencies, spawns parallel subagents to implement independent issues using the implement skill, monitors CI and review status, and iterates until the milestone is clear. Use this when asked to burn down a milestone, work through a milestone, or implement all issues in a milestone. Escalates only genuine ambiguity.
+---
+
+# Milestone Burndown
+
+Orchestrates end-to-end resolution of all open issues in a milestone. You are the supervisor — you dispatch work, monitor outcomes, and keep moving. You only surface things to the user when a decision genuinely requires human judgment.
+
+## Repo constants
+
+- Owner: `cdprice02`, Repo: `ferrish`, Base branch: `main`
+
+## Phase 1: Survey the milestone
+
+Use `mcp__plugin_github_github__search_issues` with query:
+```
+repo:cdprice02/ferrish is:open milestone:"<milestone title>"
+```
+
+List every open issue. For each one note: title, labels, any mentioned dependencies in the body (e.g., "depends on #N", "blocked by #N", "after #N").
+
+Build a simple dependency map. Issues with no blockers are the first wave; issues that depend on others wait until their blockers have merged PRs.
+
+## Phase 2: First wave — implement in parallel
+
+For all unblocked issues, spawn one subagent per issue using the `implement` skill. Each agent must:
+- Work in its own worktree (`.claude/worktrees/issue-<N>`)
+- Produce a PR — not a plan
+- Include `Closes #<N>` in the PR body
+
+Spawn them all in the same turn so they run concurrently.
+
+Brief each subagent with:
+```
+Use the implement skill to implement ferrish issue #<N>.
+Work in .claude/worktrees/issue-<N>.
+Deliver a PR URL. Do not return a plan.
+```
+
+## Phase 3: Monitor and iterate
+
+After the first wave completes, check the status of every PR using `mcp__plugin_github_github__pull_request_read` (method: `get_check_runs` and `get_review_comments`).
+
+For each PR:
+
+| State | Action |
+|-------|--------|
+| CI passing, no review comments | Nothing to do — wait for merge |
+| CI failing | Read the failure output, fix it in the worktree, push again |
+| Review comments present | Classify each comment (see below), address mechanical ones |
+| Merge conflict | Rebase the branch onto main and re-verify |
+
+### Classifying review comments
+
+- **Mechanical** (naming, formatting, missing test, small refactor): fix it, push, reply to the thread with a one-line summary of what changed
+- **Design question** (alternative approach, architectural concern): reply with a reasoned response; if you're confident in the original approach, defend it briefly; if the reviewer raises a valid point, update the code
+- **Needs human judgment** (product decision, scope change, security concern): surface it to the user with the PR number and comment text
+
+Reply to addressed threads via `mcp__plugin_github_github__add_reply_to_pull_request_comment`.
+
+## Phase 4: Unblock the next wave
+
+Once a blocking issue's PR is merged, check the dependency map for issues that were waiting on it. Add them to the active work queue and spawn their subagents.
+
+Use `mcp__plugin_github_github__search_issues` to re-query the milestone periodically and confirm what's still open.
+
+## Phase 5: Done
+
+When all issues in the milestone have closed PRs (or explicit escalations), report a summary:
+- Issues implemented: list with PR URLs
+- Issues escalated: list with reason
+- Issues still open: list with current blocker
+
+## Escalation criteria
+
+Stop and surface to the user when:
+- An issue's scope is genuinely unclear after reading the body and all comments
+- A PR has been through two fix cycles and CI is still failing in a way you can't diagnose
+- A reviewer requests a design change that would affect other issues in the milestone
+- Two issues in the same milestone modify the same core module in conflicting ways
+
+Everything else — test failures, clippy warnings, merge conflicts, mechanical review comments — handle without interrupting.

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -15,7 +15,7 @@ Orchestrates end-to-end resolution of all open issues in a milestone. You are th
 
 Use `mcp__plugin_github_github__search_issues` with query:
 ```
-repo:cdprice02/ferrish is:open milestone:"<milestone title>"
+repo:cdprice02/ferrish is:open is:issue milestone:"<milestone title>"
 ```
 
 List every open issue. For each one note: title, labels, any mentioned dependencies in the body (e.g., "depends on #N", "blocked by #N", "after #N").

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ target/
 
 # OS
 tmp/
+
+# Claude Code worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/implement/SKILL.md` — end-to-end workflow for implementing a single issue: reads the issue via GitHub MCP, creates a worktree, writes code+tests following ferrish conventions, runs `cargo test` and `cargo clippy -- -D warnings`, commits, pushes, and opens a PR
- Adds `.claude/skills/milestone/SKILL.md` — supervisor orchestration skill that surveys a milestone, identifies dependencies, spawns parallel subagents via the implement skill, then monitors CI/review status and iterates until the milestone is clear
- Adds `.claude/worktrees/` to `.gitignore` to prevent accidental staging of worktree contents

## Test plan

- [ ] Invoke `/implement <issue-number>` on a real issue and verify it produces a PR
- [ ] Invoke `/milestone "<milestone-title>"` and verify it surveys open issues and dispatches subagents

Co-Authored-By: Claude <noreply@anthropic.com>