### PR TITLE
chore: add review gate, pr-review and triage skills, MCP-first guidance

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: Implement a single ferrish GitHub issue end-to-end — reads the is
 
 # Implement
 
-End-to-end implementation of a single ferrish issue. The only output that matters is a PR URL — not a plan, not a summary of what could be done.
+End-to-end implementation of a single ferrish issue. The deliverable is a PR URL and a one-line status confirming it is open and awaiting code owner review — not a plan, not a summary of what could be done.
 
 ## Repo constants
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -12,6 +12,10 @@ End-to-end implementation of a single ferrish issue. The only output that matter
 - Owner: `cdprice02`, Repo: `ferrish`, Base branch: `main`
 - Worktrees: `.claude/worktrees/` (gitignored)
 
+## Tool priority
+
+Use `mcp__plugin_github_github__*` for all GitHub operations (reading issues, creating PRs, checking CI status, replying to review threads). Fall back to `gh` CLI via Bash only when a specific operation is unavailable through the MCP.
+
 ## Steps
 
 ### 1. Read the issue
@@ -84,6 +88,14 @@ Then open the PR via `mcp__plugin_github_github__create_pull_request`:
 - `body`: one-paragraph description of the approach, followed by `Closes #<N>`
 - `base`: `main`
 
+GitHub will automatically request a review from the code owner (via `.github/CODEOWNERS`). Do not manually assign reviewers.
+
 ### 8. Done
 
-Return the PR URL. That's the deliverable.
+Return the PR URL and state that it is open and awaiting code owner review. The skill's job ends here — do not merge.
+
+Example:
+```
+PR #N is open and awaiting code owner review.
+https://github.com/cdprice02/ferrish/pull/N
+```

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -58,9 +58,9 @@ For each PR:
 |-------|--------|
 | CI pending / running | Wait; revisit next cycle |
 | CI failing | Read failure output via MCP, fix in the worktree, push again |
-| Review comments present | Classify each comment (see below), address mechanical ones |
+| Review comments present (unresolved) | Classify each comment (see below), address mechanical ones. Skip threads where `is_resolved: true`. |
 | Merge conflict | Rebase the branch onto main, re-verify, push |
-| CI passing, review pending | Do nothing — awaiting code owner approval. Do not merge. |
+| CI passing, review pending | Do nothing — awaiting code owner review. Do not merge. |
 | CI passing, review approved | Surface to user: "PR #N has been approved and is ready for you to merge." |
 
 ### Classifying review comments
@@ -80,7 +80,7 @@ Use `mcp__plugin_github_github__list_issues` to re-query the milestone periodica
 When all remaining open PRs are green and awaiting review, stop and report:
 
 ```
-All implementation work is complete. The following PRs are green and awaiting code owner approval:
+All implementation work is complete. The following PRs are green and awaiting code owner review:
 - PR #N — <title> — <url>
 - PR #M — <title> — <url>
 

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -11,9 +11,19 @@ Orchestrates end-to-end resolution of all open issues in a milestone. You are th
 
 - Owner: `cdprice02`, Repo: `ferrish`, Base branch: `main`
 
+## Recommended workflow
+
+Run `/triage` before starting a milestone burndown to ensure all issues are labeled, scoped to the right milestone, and free of unresolved duplicates. Milestone assumes issues are already organized — it does not re-triage mid-run.
+
+For a PR with a large volume of design-level review comments, consider pausing the monitoring loop and running `/pr-review <N>` directly for more thorough handling before resuming.
+
+## Tool priority
+
+Use `mcp__plugin_github_github__*` for all GitHub operations (issue listing, PR status, CI checks, review comment replies). Fall back to `gh` CLI via Bash only when a specific operation is unavailable through the MCP.
+
 ## Phase 1: Survey the milestone
 
-Use `mcp__plugin_github_github__search_issues` with query:
+Use `mcp__plugin_github_github__list_issues` with a milestone filter, or `mcp__plugin_github_github__search_issues` with query:
 ```
 repo:cdprice02/ferrish is:open is:issue milestone:"<milestone title>"
 ```
@@ -40,34 +50,46 @@ Deliver a PR URL. Do not return a plan.
 
 ## Phase 3: Monitor and iterate
 
-After the first wave completes, check the status of every PR using `mcp__plugin_github_github__pull_request_read` (method: `get_check_runs` and `get_review_comments`).
+After the first wave completes, check the status of every PR using `mcp__plugin_github_github__pull_request_read` (methods: `get`, `get_check_runs`, `get_review_comments`).
 
 For each PR:
 
 | State | Action |
 |-------|--------|
-| CI passing, no review comments | Nothing to do — wait for merge |
-| CI failing | Read the failure output, fix it in the worktree, push again |
+| CI pending / running | Wait; revisit next cycle |
+| CI failing | Read failure output via MCP, fix in the worktree, push again |
 | Review comments present | Classify each comment (see below), address mechanical ones |
-| Merge conflict | Rebase the branch onto main and re-verify |
+| Merge conflict | Rebase the branch onto main, re-verify, push |
+| CI passing, review pending | Do nothing — awaiting code owner approval. Do not merge. |
+| CI passing, review approved | Surface to user: "PR #N is approved and ready for you to merge." |
 
 ### Classifying review comments
 
-- **Mechanical** (naming, formatting, missing test, small refactor): fix it, push, reply to the thread with a one-line summary of what changed
-- **Design question** (alternative approach, architectural concern): reply with a reasoned response; if you're confident in the original approach, defend it briefly; if the reviewer raises a valid point, update the code
+- **Mechanical** (naming, formatting, missing test, small refactor): fix it, push, reply to the thread via `mcp__plugin_github_github__add_reply_to_pull_request_comment` with a one-line summary of what changed
+- **Design question** (alternative approach, architectural concern): reply with a reasoned response via MCP; if you're confident in the original approach, defend it briefly; if the reviewer raises a valid point, update the code
 - **Needs human judgment** (product decision, scope change, security concern): surface it to the user with the PR number and comment text
-
-Reply to addressed threads via `mcp__plugin_github_github__add_reply_to_pull_request_comment`.
 
 ## Phase 4: Unblock the next wave
 
 Once a blocking issue's PR is merged, check the dependency map for issues that were waiting on it. Add them to the active work queue and spawn their subagents.
 
-Use `mcp__plugin_github_github__search_issues` to re-query the milestone periodically and confirm what's still open.
+Use `mcp__plugin_github_github__list_issues` to re-query the milestone periodically and confirm what's still open.
 
 ## Phase 5: Done
 
-When all issues in the milestone have closed PRs (or explicit escalations), report a summary:
+When all remaining open PRs are green and awaiting review, stop and report:
+
+```
+All implementation work is complete. The following PRs are green and awaiting your approval:
+- PR #N — <title> — <url>
+- PR #M — <title> — <url>
+
+Merge these at your discretion. Issues will close automatically via the "Closes #N" link.
+```
+
+Do not poll indefinitely after reaching this state.
+
+When all issues in the milestone have closed PRs (or explicit escalations), report a final summary:
 - Issues implemented: list with PR URLs
 - Issues escalated: list with reason
 - Issues still open: list with current blocker

--- a/.claude/skills/milestone/SKILL.md
+++ b/.claude/skills/milestone/SKILL.md
@@ -50,7 +50,7 @@ Deliver a PR URL. Do not return a plan.
 
 ## Phase 3: Monitor and iterate
 
-After the first wave completes, check the status of every PR using `mcp__plugin_github_github__pull_request_read` (methods: `get`, `get_check_runs`, `get_review_comments`).
+After the first wave completes, check the status of every PR using `mcp__plugin_github_github__pull_request_read` (methods: `get`, `get_check_runs`, `get_review_comments`, `get_reviews`). Use `get_reviews` to determine whether a PR is approved, has changes requested, or is still awaiting review.
 
 For each PR:
 
@@ -61,7 +61,7 @@ For each PR:
 | Review comments present | Classify each comment (see below), address mechanical ones |
 | Merge conflict | Rebase the branch onto main, re-verify, push |
 | CI passing, review pending | Do nothing — awaiting code owner approval. Do not merge. |
-| CI passing, review approved | Surface to user: "PR #N is approved and ready for you to merge." |
+| CI passing, review approved | Surface to user: "PR #N has been approved and is ready for you to merge." |
 
 ### Classifying review comments
 
@@ -80,11 +80,11 @@ Use `mcp__plugin_github_github__list_issues` to re-query the milestone periodica
 When all remaining open PRs are green and awaiting review, stop and report:
 
 ```
-All implementation work is complete. The following PRs are green and awaiting your approval:
+All implementation work is complete. The following PRs are green and awaiting code owner approval:
 - PR #N — <title> — <url>
 - PR #M — <title> — <url>
 
-Merge these at your discretion. Issues will close automatically via the "Closes #N" link.
+Merge these at your discretion once approved. Issues will close automatically via the "Closes #N" link.
 ```
 
 Do not poll indefinitely after reaching this state.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -71,8 +71,10 @@ fix: address review comments on PR #N
 ```
 
 ```bash
-git push
+git push origin HEAD:<branch-name>
 ```
+
+Use the PR's upstream branch name (from `get` in step 1) as `<branch-name>`. This is explicit and works correctly regardless of `push.default` when the local worktree branch name differs from the upstream.
 
 ### 7. Reply to addressed threads and resolve them
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -22,10 +22,10 @@ Use `mcp__plugin_github_github__*` for all GitHub reads and writes (fetching PR 
 
 Use `mcp__plugin_github_github__pull_request_read`:
 - `get` — PR metadata, current branch name, head SHA
-- `get_review_comments` — all inline review comments
+- `get_review_comments` — all inline review threads; each thread includes `is_resolved` — skip threads where `is_resolved: true`
 - `get_reviews` — top-level review summaries (approved, changes requested, commented)
 
-Focus on unresolved threads. Skip comments that are already resolved or that have been replied to by the author.
+Focus on unresolved threads (`is_resolved: false`). Skip threads that are already resolved or where the author has already replied with a fix.
 
 ### 2. Classify each comment
 
@@ -42,7 +42,7 @@ When in doubt between mechanical and design, treat it as design — don't silent
 Check out the PR branch in an isolated worktree:
 
 ```bash
-git worktree add .claude/worktrees/pr-<N>-review origin/<branch-name>
+git worktree add .claude/worktrees/pr-<N>-review -b pr-<N>-review --track origin/<branch-name>
 ```
 
 All edits and verification commands run inside that worktree.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -76,8 +76,10 @@ git push
 
 ### 7. Reply to addressed threads
 
-For each resolved mechanical comment, reply via `mcp__plugin_github_github__add_reply_to_pull_request_comment` with a one-line summary:
-> Fixed — <what changed in one sentence>
+For each resolved mechanical comment, reply via `mcp__plugin_github_github__add_reply_to_pull_request_comment` with a one-line summary that includes the commit link:
+> Fixed in <commit SHA short> — <what changed in one sentence>
+
+GitHub auto-links short SHAs in PR comments. Use the short SHA of the commit you just pushed (first 7 characters).
 
 For design questions where the original approach is sound:
 > Keeping the current approach because <reason>. <Optional: what would need to change for the alternative to be preferable.>

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: pr-review
+description: Respond to review comments on a ferrish pull request — fetches all unresolved comments, classifies them, implements mechanical fixes, runs tests and clippy, pushes, and replies to threads via MCP. Surfaces design questions and judgment calls to the user. Use whenever asked to address, respond to, or fix review comments on a PR.
+---
+
+# PR Review Response
+
+Addresses review comments on a single ferrish PR end-to-end. Mechanical fixes get implemented and pushed. Design questions get a reasoned reply. Anything requiring human judgment gets surfaced to you.
+
+## Repo constants
+
+- Owner: `cdprice02`, Repo: `ferrish`, Base branch: `main`
+- Worktrees: `.claude/worktrees/` (gitignored)
+
+## Tool priority
+
+Use `mcp__plugin_github_github__*` for all GitHub reads and writes (fetching PR details, reading review comments, posting replies). Fall back to `gh` CLI via Bash only when a specific operation is unavailable through the MCP.
+
+## Steps
+
+### 1. Fetch the PR and its review comments
+
+Use `mcp__plugin_github_github__pull_request_read`:
+- `get` — PR metadata, current branch name, head SHA
+- `get_review_comments` — all inline review comments
+- `get_reviews` — top-level review summaries (approved, changes requested, commented)
+
+Focus on unresolved threads. Skip comments that are already resolved or that have been replied to by the author.
+
+### 2. Classify each comment
+
+| Class | Criteria | Action |
+|-------|----------|--------|
+| **Mechanical** | Naming, formatting, missing test, trivial refactor, typo | Fix in code, push, reply |
+| **Design question** | Alternative approach, architectural concern, "why not X?" | Reply with reasoning via MCP; update code if the reviewer's point is valid |
+| **Needs human judgment** | Product decision, security concern, scope change, contradicts a prior decision | Surface to user with full comment text |
+
+When in doubt between mechanical and design, treat it as design — don't silently change semantics.
+
+### 3. Set up the worktree
+
+Check out the PR branch in an isolated worktree:
+
+```bash
+git worktree add .claude/worktrees/pr-<N>-review origin/<branch-name>
+```
+
+All edits and verification commands run inside that worktree.
+
+### 4. Implement mechanical fixes
+
+Read the relevant source files first. Apply all mechanical fixes in one pass. Follow ferrish conventions:
+- File-based modules only — no `mod.rs`
+- All I/O through `ShellIo`; `MockIo` in tests
+- Integration tests via `ShellTest` builder in `tests/harness.rs`
+
+### 5. Verify
+
+```bash
+cargo test
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Fix anything that fails before pushing. Do not push a red build.
+
+### 6. Commit and push
+
+One commit for all mechanical fixes:
+```
+fix: address review comments on PR #N
+```
+
+```bash
+git push
+```
+
+### 7. Reply to addressed threads
+
+For each resolved mechanical comment, reply via `mcp__plugin_github_github__add_reply_to_pull_request_comment` with a one-line summary:
+> Fixed — <what changed in one sentence>
+
+For design questions where the original approach is sound:
+> Keeping the current approach because <reason>. <Optional: what would need to change for the alternative to be preferable.>
+
+For design questions where the reviewer's point is valid and code was updated:
+> Good call — updated in <commit SHA short>. <One sentence on what changed.>
+
+### 8. Surface judgment calls
+
+For each `Needs human judgment` comment, present to the user:
+
+```
+PR #N — comment by @<reviewer> on <file>:<line>
+"<comment text>"
+
+This needs your input because: <reason — product decision / security concern / scope question>
+```
+
+Wait for direction before taking any action on these.
+
+### 9. Report
+
+Return a summary:
+```
+PR #N review response complete.
+- Mechanical fixes: N (pushed, threads replied)
+- Design replies: M (no code change)
+- Awaiting your input: K (listed above)
+```

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -74,18 +74,26 @@ fix: address review comments on PR #N
 git push
 ```
 
-### 7. Reply to addressed threads
+### 7. Reply to addressed threads and resolve them
 
 For each resolved mechanical comment, reply via `mcp__plugin_github_github__add_reply_to_pull_request_comment` with a one-line summary that includes the commit link:
 > Fixed in <commit SHA short> — <what changed in one sentence>
 
 GitHub auto-links short SHAs in PR comments. Use the short SHA of the commit you just pushed (first 7 characters).
 
-For design questions where the original approach is sound:
+Then resolve the thread. The thread's `node_id` is returned by `get_review_comments` — use it with the GraphQL API:
+
+```bash
+gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread node_id>"}) { thread { isResolved } } }'
+```
+
+For design questions where the original approach is sound, reply and resolve:
 > Keeping the current approach because <reason>. <Optional: what would need to change for the alternative to be preferable.>
 
-For design questions where the reviewer's point is valid and code was updated:
+For design questions where the reviewer's point is valid and code was updated, reply and resolve:
 > Good call — updated in <commit SHA short>. <One sentence on what changed.>
+
+**Do not resolve** threads for `Needs human judgment` items or for design replies that explicitly invite further discussion — leave those open for the conversation to continue.
 
 ### 8. Surface judgment calls
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: triage
+description: Triage open ferrish issues — reads each issue body, proposes label assignments, milestone placements, and flags duplicates. Presents a report for approval before applying any changes. Use when asked to triage, organize, label, or prioritize open issues.
+---
+
+# Issue Triage
+
+Reads every open issue, proposes label and milestone assignments, flags duplicates, and surfaces ambiguous cases. Nothing is applied until you confirm.
+
+## Repo constants
+
+- Owner: `cdprice02`, Repo: `ferrish`
+
+## Recommended workflow
+
+Run triage before starting a `/milestone` burndown. Milestone assumes issues are already labeled and scoped — triage is the preparation step that makes that true. The suggested order is:
+
+1. `/triage` — organize the backlog, confirm milestone assignments
+2. `/milestone <name>` — implement everything in the milestone
+
+## Tool priority
+
+Use `mcp__plugin_github_github__*` for all GitHub reads and writes. Fall back to `gh` CLI via Bash (e.g., `gh milestone list`) only when the MCP does not expose the needed operation.
+
+## Steps
+
+### 1. Fetch current state (run in parallel)
+
+- **Open issues:** `mcp__plugin_github_github__list_issues` (state: open)
+- **Existing labels:** `mcp__plugin_github_github__get_label` for each known label — `bug`, `enhancement`, `chore`, `docs`, `refactor`
+- **Open milestones:** `mcp__plugin_github_github__list_issues` grouped by milestone, or `gh milestone list` as fallback
+
+### 2. Read each issue
+
+Use `mcp__plugin_github_github__issue_read` (method: `get`) for the full body of each open issue. Skim for:
+
+| Signal | Suggests |
+|--------|----------|
+| panic, crash, fail, wrong, unexpected, broken | `bug` |
+| add, support, allow, implement, introduce | `enhancement` |
+| CI, workflow, deps, dependency, tooling, lint | `chore` |
+| document, explain, clarify, readme | `docs` |
+| restructure, reorganize, rename, move, extract | `refactor` |
+| references to a specific module or file | fits in an existing milestone targeting that area |
+| "depends on #N", "blocked by #N" | dependency — note for ordering |
+
+If an issue already has a label, do not propose changing it unless there is a clear mismatch.
+
+### 3. Build the triage report
+
+Do not apply any changes yet. Produce a structured report:
+
+```
+## Triage Report — <date>
+
+### Proposed label assignments
+- #N "<title>": (unlabeled) → bug — "panics when empty input..."
+- #M "<title>": (unlabeled) → enhancement — "adds support for..."
+[omit issues that already have correct labels]
+
+### Proposed milestone assignments
+- #N → Milestone X — fits scope alongside issues #A, #B (same module)
+- #P → no clear fit — see questions below
+
+### Possible duplicates / related issues
+- #N and #M both describe quoting edge cases — consider consolidating or cross-linking
+[omit if no overlaps found]
+
+### Questions for you
+- #P: unclear whether this is a bug fix or a new capability — which label and milestone?
+- #Q: mentions a design change that might conflict with #R — should these be sequenced?
+[only include genuinely ambiguous cases]
+```
+
+### 4. Present and confirm
+
+Show the report. Ask:
+> Apply all proposed changes, or review item by item?
+
+Wait for the response before proceeding. If the user says "apply all," proceed to step 5. If "item by item," walk through each proposed change and apply only confirmed ones.
+
+### 5. Apply confirmed changes
+
+For each confirmed assignment, use `mcp__plugin_github_github__issue_write` (method: `update`):
+- Labels: set the `labels` field (additive — preserve existing labels)
+- Milestone: set the `milestone` field using the milestone number
+
+For flagged duplicates: only surface them. Never close, link, or comment on issues without explicit instruction.
+
+### 6. Report applied changes
+
+```
+Triage complete.
+- Labels applied: N issues updated
+- Milestone assignments: M issues updated
+- Flagged for your attention: K items (duplicates / questions)
+```

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -27,8 +27,8 @@ Use `mcp__plugin_github_github__*` for all GitHub reads and writes. Fall back to
 ### 1. Fetch current state (run in parallel)
 
 - **Open issues:** `mcp__plugin_github_github__list_issues` (state: open)
-- **Existing labels:** `mcp__plugin_github_github__get_label` for each known label — `bug`, `enhancement`, `chore`, `docs`, `refactor`
-- **Open milestones:** `mcp__plugin_github_github__list_issues` grouped by milestone, or `gh milestone list` as fallback
+- **All labels:** `gh label list` via Bash — fetches the full set of repo-defined labels, not just a hard-coded subset. Use this as the label universe when proposing assignments.
+- **Open milestones:** `gh milestone list` via Bash — lists milestones directly, including those with zero open issues which `list_issues` would miss.
 
 ### 2. Read each issue
 

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -27,8 +27,8 @@ Use `mcp__plugin_github_github__*` for all GitHub reads and writes. Fall back to
 ### 1. Fetch current state (run in parallel)
 
 - **Open issues:** `mcp__plugin_github_github__list_issues` (state: open)
-- **All labels:** `gh label list` via Bash — fetches the full set of repo-defined labels, not just a hard-coded subset. Use this as the label universe when proposing assignments.
-- **Open milestones:** `gh milestone list` via Bash — lists milestones directly, including those with zero open issues which `list_issues` would miss.
+- **All labels:** `gh label list` via Bash — the MCP does not expose a label-listing operation, so `gh` is the correct tool here per the tool priority guidance. Fetches the full set of repo-defined labels. Use this as the label universe when proposing assignments.
+- **Open milestones:** `gh milestone list` via Bash — the MCP does not expose milestone listing, so `gh` is the correct tool here. Lists all milestones directly, including those with zero open issues which `list_issues` would miss.
 
 ### 2. Read each issue
 
@@ -82,7 +82,7 @@ Wait for the response before proceeding. If the user says "apply all," proceed t
 ### 5. Apply confirmed changes
 
 For each confirmed assignment, use `mcp__plugin_github_github__issue_write` (method: `update`):
-- Labels: set the `labels` field (additive — preserve existing labels)
+- Labels: the GitHub API replaces the label set entirely — do not send only the new label. First read the issue's current labels, then send the union of existing labels plus the newly proposed one.
 - Milestone: set the `milestone` field using the milestone number
 
 For flagged duplicates: only surface them. Never close, link, or comment on issues without explicit instruction.


### PR DESCRIPTION
## Summary

- **Human review gate**: `implement` now relies on `.github/CODEOWNERS` + branch protection for reviewer assignment (no hardcoded usernames) and explicitly states the PR is awaiting code owner review rather than "done". `milestone` Phase 3 monitoring table distinguishes review-pending from review-approved, and Phase 5 stops at a "awaiting your approval" report instead of claiming the milestone is finished.
- **MCP-first guidance**: Both `implement` and `milestone` now open with a tool-priority preamble directing the agent to use `mcp__plugin_github_github__*` for all GitHub operations, with `gh` CLI as fallback only.
- **`/pr-review` skill (new)**: Encodes the full review-response loop — fetch unresolved comments, classify (mechanical / design / judgment), implement fixes, run `cargo test` + `cargo clippy`, push, reply to threads via MCP, surface judgment calls to user.
- **`/triage` skill (new)**: Reads all open issues, proposes label and milestone assignments, flags duplicates, presents a confirmation report before applying any changes. Includes a recommended-workflow note pointing to `/milestone`.
- **Cross-references**: `milestone` notes to run `/triage` first and that heavy design-review PRs can be handed off to `/pr-review <N>`. `triage` documents the two-step sequence: triage → milestone.

## Test plan

- [ ] Run `/implement` on a small issue; confirm PR opens with code owner auto-requested and output reads "awaiting code owner review"
- [ ] Run `/milestone` on a milestone; confirm Phase 5 produces an "awaiting your approval" list rather than claiming completion
- [ ] Run `/pr-review <N>` on a PR with review comments; confirm mechanical fixes are pushed and threads replied to via MCP
- [ ] Run `/triage`; confirm report is produced and no changes are applied before confirmation

Co-Authored-By: Claude <noreply@anthropic.com>