### PR TITLE
chore: gate test on build, release on test via workflow_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: build release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
 name: release
 
 on:
-  push:
+  workflow_run:
+    workflows: [test]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
 jobs:
   release:
     name: release (${{ matrix.os }})
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,15 @@ name: test
 on:
   pull_request:
     branches: [main]
-  push:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
     branches: [main]
 
 jobs:
   test:
     name: test
+    if: ${{ github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: test


### PR DESCRIPTION
Use `workflow_run` to enforce CI ordering across separate workflow files, avoiding the false-green where `test` runs against stale cached artifacts before the current push's `build` completes.

- `test.yml`: replaces `push` trigger with `workflow_run` on `build` completing; job only runs if the build succeeded. The `pull_request` trigger is kept so tests still run on PRs.
- `release.yml`: replaces `push` trigger with `workflow_run` on `test` completing; job only runs if tests passed. `workflow_dispatch` is retained for manual releases.
- `lint.yml`: no changes — `coverage` already correctly `needs: [lint]`.

Keeping the workflows in separate files preserves the per-file badge URLs in `README.md`.

Closes #81