### PR TITLE
feat: stdout redirection (> and 1>) operators

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -67,8 +67,8 @@ pub fn execute(
 ) -> ShellResult<Option<ExitCode>> {
     if let Some(ref redir) = redirect {
         // Resolve the redirect target path relative to the current working directory.
-        let target_path = if std::path::Path::new(&redir.target).is_absolute() {
-            PathBuf::from(&redir.target)
+        let target_path = if redir.target.is_absolute() {
+            redir.target.clone()
         } else {
             ctx.cwd.join(&redir.target)
         };
@@ -402,7 +402,7 @@ mod tests {
         let target = dir.path().join("out.txt");
         let mut ctx = ShellCtx::new(None, dir.path().to_path_buf());
         let mut io = MockIo::empty();
-        let redir = Some(crate::redirect::Redirect::new(target.to_str().unwrap()));
+        let redir = Some(crate::redirect::Redirect::new(target.clone()));
         let result = execute(
             Command::BuiltIn(BuiltInCommand::new(BuiltInName::Echo)),
             vec![Arg::from("hello")],

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,6 +13,7 @@ use crate::{
     exit::ExitCode,
     fs,
     io::ShellIo,
+    redirect::Redirect,
 };
 
 enum CommandKind {
@@ -52,16 +53,48 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
 
 /// Dispatch and execute a parsed command, returning an optional exit code.
 ///
+/// When `redirect` is `Some`, the command's standard output is written to the
+/// named file (creating or overwriting it) instead of the shell's normal
+/// stdout.  Standard error always goes to the shell's stderr stream.
+///
 /// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
 pub fn execute(
     command: Command,
     args: Args,
     io: &mut impl ShellIo,
     ctx: &mut ShellCtx,
+    redirect: Option<Redirect>,
+) -> ShellResult<Option<ExitCode>> {
+    if let Some(ref redir) = redirect {
+        // Resolve the redirect target path relative to the current working directory.
+        let target_path = if std::path::Path::new(&redir.target).is_absolute() {
+            PathBuf::from(&redir.target)
+        } else {
+            ctx.cwd.join(&redir.target)
+        };
+
+        let mut file = std::fs::File::create(&target_path).map_err(ShellError::Io)?;
+        execute_with_writers(command, args, &mut file, io.err_writer(), ctx)
+    } else {
+        let (out, err) = io.writers();
+        execute_with_writers(command, args, out, err, ctx)
+    }
+}
+
+/// Core dispatch: all output goes to the provided `out` and `err` writers.
+///
+/// This separation makes it possible to redirect stdout to a file while keeping
+/// stderr on the terminal without changing the `ShellIo` abstraction.
+fn execute_with_writers(
+    command: Command,
+    args: Args,
+    out: &mut dyn std::io::Write,
+    err: &mut dyn std::io::Write,
+    ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     match command {
-        Command::BuiltIn(builtin) => execute_builtin(builtin, args, io, ctx),
-        Command::Executable(executable) => execute_executable(executable, args, io, ctx),
+        Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
+        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx),
         Command::Unrecognized(_) => Err(ShellError::CommandNotFound),
     }
 }
@@ -69,7 +102,8 @@ pub fn execute(
 fn execute_builtin(
     builtin: BuiltInCommand,
     args: Args,
-    io: &mut impl ShellIo,
+    out: &mut dyn std::io::Write,
+    err: &mut dyn std::io::Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     match builtin.name() {
@@ -81,7 +115,7 @@ fn execute_builtin(
                     match s.parse::<u8>() {
                         Ok(n) => ExitCode(n),
                         Err(_) => {
-                            writeln!(io.err_writer(), "exit: {}: numeric argument required", s)?;
+                            writeln!(err, "exit: {}: numeric argument required", s)?;
                             return Ok(Some(ExitCode::FAILURE));
                         }
                     }
@@ -89,16 +123,16 @@ fn execute_builtin(
             };
             return Ok(Some(code));
         }
-        BuiltInName::Cd => execute_cd(args, io, ctx)?,
-        BuiltInName::Echo => execute_echo(args, io)?,
-        BuiltInName::Type => execute_type(args, io)?,
-        BuiltInName::Pwd => execute_pwd(args, io, ctx)?,
+        BuiltInName::Cd => execute_cd(args, ctx)?,
+        BuiltInName::Echo => execute_echo(args, out)?,
+        BuiltInName::Type => execute_type(args, out)?,
+        BuiltInName::Pwd => execute_pwd(args, out, ctx)?,
     }
 
     Ok(None)
 }
 
-fn execute_cd(args: Args, _io: &mut impl ShellIo, ctx: &mut ShellCtx) -> ShellResult<()> {
+fn execute_cd(args: Args, ctx: &mut ShellCtx) -> ShellResult<()> {
     let default_target = Arg::from(b"~".as_slice());
     let target = args.first().unwrap_or(&default_target);
     let new_dir = fs::resolve_path(&target.into(), ctx.home_dir.as_deref(), &ctx.cwd)?;
@@ -118,9 +152,9 @@ fn execute_cd(args: Args, _io: &mut impl ShellIo, ctx: &mut ShellCtx) -> ShellRe
     Ok(())
 }
 
-fn execute_echo(args: Args, io: &mut impl ShellIo) -> ShellResult<()> {
+fn execute_echo(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
     writeln!(
-        io.out_writer(),
+        out,
         "{}",
         args.iter()
             .map(|a| a.to_string())
@@ -131,7 +165,7 @@ fn execute_echo(args: Args, io: &mut impl ShellIo) -> ShellResult<()> {
     Ok(())
 }
 
-fn execute_type(args: Args, io: &mut impl ShellIo) -> ShellResult<()> {
+fn execute_type(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
     if args.is_empty() {
         return Err(ShellError::MissingOperand);
     }
@@ -141,14 +175,14 @@ fn execute_type(args: Args, io: &mut impl ShellIo) -> ShellResult<()> {
 
     match resolve_command_type(name) {
         CommandKind::Builtin(builtin_name) => {
-            writeln!(io.out_writer(), "{} is a shell builtin", builtin_name)?
+            writeln!(out, "{} is a shell builtin", builtin_name)?
         }
         CommandKind::Executable(path) => {
             let display_name = path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("");
-            writeln!(io.out_writer(), "{} is {}", display_name, path.display())?
+            writeln!(out, "{} is {}", display_name, path.display())?
         }
         CommandKind::NotFound => return Err(ShellError::CommandNotFound),
     }
@@ -156,15 +190,20 @@ fn execute_type(args: Args, io: &mut impl ShellIo) -> ShellResult<()> {
     Ok(())
 }
 
-fn execute_pwd(_args: Args, io: &mut impl ShellIo, ctx: &ShellCtx) -> ShellResult<()> {
-    writeln!(io.out_writer(), "{}", ctx.cwd.display())?;
+fn execute_pwd(
+    _args: Args,
+    out: &mut dyn std::io::Write,
+    ctx: &ShellCtx,
+) -> ShellResult<()> {
+    writeln!(out, "{}", ctx.cwd.display())?;
     Ok(())
 }
 
 fn execute_executable(
     executable: crate::command::executable::ExecutableCommand,
     args: Args,
-    io: &mut impl ShellIo,
+    out: &mut dyn std::io::Write,
+    err: &mut dyn std::io::Write,
     ctx: &ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     use std::process::Stdio;
@@ -183,8 +222,8 @@ fn execute_executable(
     // if the child fills one pipe's buffer while we are blocked reading the
     // other, neither side can make progress.  `ChildStdout`/`ChildStderr` are
     // `Send`, so they can be moved into threads safely.  We accumulate bytes
-    // into `Vec<u8>` and write them into `ShellIo` after joining — keeping
-    // the `?Send` `ShellIo` exclusively on the calling thread.
+    // into `Vec<u8>` and write them into the writers after joining — keeping
+    // the `?Send` writers exclusively on the calling thread.
     let stdout_thread = child.stdout.take().map(|mut pipe| {
         thread::spawn(move || -> std::io::Result<Vec<u8>> {
             let mut buf = Vec::new();
@@ -206,11 +245,11 @@ fn execute_executable(
     // Collect thread results; propagate the first I/O error encountered.
     if let Some(handle) = stdout_thread {
         let bytes = join_io_thread(handle, "stdout")?;
-        io.out_writer().write_all(&bytes)?;
+        out.write_all(&bytes)?;
     }
     if let Some(handle) = stderr_thread {
         let bytes = join_io_thread(handle, "stderr")?;
-        io.err_writer().write_all(&bytes)?;
+        err.write_all(&bytes)?;
     }
 
     if !status.success() {
@@ -247,11 +286,26 @@ mod tests {
         ShellCtx::new(None, std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")))
     }
 
+    fn run_builtin(
+        builtin: BuiltInName,
+        args: Vec<Arg>,
+        io: &mut MockIo,
+        ctx: &mut ShellCtx,
+    ) -> ShellResult<Option<ExitCode>> {
+        execute(
+            Command::BuiltIn(BuiltInCommand::new(builtin)),
+            args,
+            io,
+            ctx,
+            None,
+        )
+    }
+
     #[test]
     fn test_execute_builtin_exit() {
         let mut io = MockIo::empty();
         let mut ctx = test_ctx();
-        let result = execute_builtin(BuiltInCommand::new(BuiltInName::Exit), vec![], &mut io, &mut ctx);
+        let result = run_builtin(BuiltInName::Exit, vec![], &mut io, &mut ctx);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(ExitCode::SUCCESS));
     }
@@ -260,8 +314,8 @@ mod tests {
     fn test_execute_builtin_exit_with_code() {
         let mut io = MockIo::empty();
         let mut ctx = test_ctx();
-        let result = execute_builtin(
-            BuiltInCommand::new(BuiltInName::Exit),
+        let result = run_builtin(
+            BuiltInName::Exit,
             vec![Arg::from("1")],
             &mut io,
             &mut ctx,
@@ -272,16 +326,16 @@ mod tests {
     #[test]
     fn test_execute_type_builtin() {
         let args = vec![Arg::from("echo")];
-        let mut io = MockIo::empty();
-        execute_type(args, &mut io).unwrap();
-        assert_eq!(io.output(), b"echo is a shell builtin\n");
+        let mut out: Vec<u8> = Vec::new();
+        execute_type(args, &mut out).unwrap();
+        assert_eq!(out, b"echo is a shell builtin\n");
     }
 
     #[test]
     fn test_execute_type_unrecognized() {
         let args = vec![Arg::from("nonexistentcommand")];
-        let mut io = MockIo::empty();
-        let result = execute_type(args, &mut io);
+        let mut out: Vec<u8> = Vec::new();
+        let result = execute_type(args, &mut out);
         assert!(result.is_err());
         assert_eq!(result.err().unwrap(), ShellError::CommandNotFound);
     }
@@ -289,18 +343,18 @@ mod tests {
     #[test]
     fn test_execute_type_exit_builtin() {
         let args = vec![Arg::from("exit")];
-        let mut io = MockIo::empty();
-        execute_type(args, &mut io).unwrap();
-        assert_eq!(io.output(), b"exit is a shell builtin\n");
+        let mut out: Vec<u8> = Vec::new();
+        execute_type(args, &mut out).unwrap();
+        assert_eq!(out, b"exit is a shell builtin\n");
     }
 
     #[test]
     fn test_execute_builtin_pwd() {
         let cwd = PathBuf::from("/some/test/path");
         let ctx = ShellCtx::new(None, cwd.clone());
-        let mut io = MockIo::empty();
-        execute_pwd(vec![], &mut io, &ctx).unwrap();
-        assert_eq!(io.output(), format!("{}\n", cwd.display()).as_bytes());
+        let mut out: Vec<u8> = Vec::new();
+        execute_pwd(vec![], &mut out, &ctx).unwrap();
+        assert_eq!(out, format!("{}\n", cwd.display()).as_bytes());
     }
 
     #[cfg(unix)]
@@ -324,14 +378,14 @@ mod tests {
         unsafe { std::env::set_var("PATH", &new_path) };
 
         let args = vec![Arg::from("my_test_tool")];
-        let mut io = MockIo::empty();
-        let result = execute_type(args, &mut io);
+        let mut out: Vec<u8> = Vec::new();
+        let result = execute_type(args, &mut out);
 
         // SAFETY: test-only, single-threaded context
         unsafe { std::env::set_var("PATH", &original_path) };
 
         result.unwrap();
-        let output = String::from_utf8(io.output().to_vec()).unwrap();
+        let output = String::from_utf8(out).unwrap();
         assert!(
             output.contains("my_test_tool is"),
             "unexpected output: {output}"
@@ -340,6 +394,27 @@ mod tests {
             output.contains(bin_path.to_str().unwrap()),
             "path not in output: {output}"
         );
+    }
+
+    #[test]
+    fn test_execute_echo_with_redirect_writes_to_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let target = dir.path().join("out.txt");
+        let mut ctx = ShellCtx::new(None, dir.path().to_path_buf());
+        let mut io = MockIo::empty();
+        let redir = Some(crate::redirect::Redirect::new(target.to_str().unwrap()));
+        let result = execute(
+            Command::BuiltIn(BuiltInCommand::new(BuiltInName::Echo)),
+            vec![Arg::from("hello")],
+            &mut io,
+            &mut ctx,
+            redir,
+        );
+        assert!(result.is_ok(), "execute with redirect should succeed: {result:?}");
+        // stdout (io.output) should be empty — echo went to the file.
+        assert_eq!(io.output(), b"", "terminal stdout should be empty");
+        let contents = std::fs::read_to_string(&target).expect("redirect file");
+        assert_eq!(contents, "hello\n");
     }
 
     #[test]

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,6 +8,12 @@ pub trait ShellIo {
     fn out_writer(&mut self) -> &mut dyn Write;
     /// Return a mutable reference to the standard error writer.
     fn err_writer(&mut self) -> &mut dyn Write;
+    /// Return mutable references to both the stdout and stderr writers simultaneously.
+    ///
+    /// This is needed when the caller must hold both writers at the same time
+    /// (e.g. to write command output to a redirected file while still sending
+    /// error messages to the terminal stderr).
+    fn writers(&mut self) -> (&mut dyn Write, &mut dyn Write);
 
     /// Read one line (up to and including `\n`) into `buffer`.
     fn read_line(&mut self, buffer: &mut Vec<u8>) -> io::Result<usize> {
@@ -44,6 +50,10 @@ impl ShellIo for StandardIo {
 
     fn err_writer(&mut self) -> &mut dyn Write {
         &mut self.err_writer
+    }
+
+    fn writers(&mut self) -> (&mut dyn Write, &mut dyn Write) {
+        (&mut self.out_writer, &mut self.err_writer)
     }
 }
 
@@ -106,6 +116,10 @@ impl ShellIo for MockIo {
 
     fn err_writer(&mut self) -> &mut dyn Write {
         &mut self.error
+    }
+
+    fn writers(&mut self) -> (&mut dyn Write, &mut dyn Write) {
+        (&mut self.output, &mut self.error)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod fs;
 pub mod io;
 /// Input parsing: splits raw bytes into a command and its arguments.
 pub mod parser;
+/// Stdout redirection descriptors produced by the parser.
+pub mod redirect;
 /// The interactive REPL shell.
 pub mod shell;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,8 +35,23 @@ pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>) {
 /// Scan `raw_args` for an unquoted `>` or `1>` redirect operator.
 ///
 /// Returns the remaining argument list (with the operator and its target
-/// filename removed) and an optional [`Redirect`].  The *last* redirect
-/// operator wins if multiple appear (matches bash behaviour).
+/// filename removed) and an optional [`Redirect`]. If multiple redirect
+/// operators appear, only the last one is returned; earlier redirect
+/// operators are stripped from the argument list but do not trigger
+/// intermediate bash-style side effects such as creating or truncating
+/// their targets.
+///
+/// When a redirect operator appears without a following filename token (e.g.
+/// a trailing `>`), the operator is kept as a normal argument rather than
+/// silently dropped.
+///
+/// # Quoting caveat
+/// Only tokens with [`QuoteStyle::None`] are treated as potential operators.
+/// In this codebase `QuoteStyle::None` covers both truly-unquoted tokens
+/// *and* mixed-quoting contexts (e.g. `1'>'`), so a mixed token whose bytes
+/// happen to be `1>` would also be recognised as a redirect operator.
+/// Distinguishing the two cases would require a dedicated `QuoteStyle::Mixed`
+/// variant; that is left for a future quoting-improvements pass.
 fn extract_redirect(
     raw_args: Vec<(Vec<u8>, QuoteStyle)>,
 ) -> (Vec<(Vec<u8>, QuoteStyle)>, Option<Redirect>) {
@@ -51,12 +66,15 @@ fn extract_redirect(
             if token == b">" || token == b"1>" {
                 // The next token is the redirect target.
                 if let Some((target_bytes, _)) = iter.next() {
-                    let target = String::from_utf8_lossy(&target_bytes).into_owned();
+                    let target = std::path::PathBuf::from(
+                        String::from_utf8_lossy(&target_bytes).as_ref(),
+                    );
                     redirect = Some(Redirect::new(target));
+                } else {
+                    // No filename follows the operator — keep it as a literal
+                    // argument rather than silently dropping it.
+                    out_args.push((bytes, style));
                 }
-                // If there is no next token we silently drop the operator; a
-                // real shell would error, but error handling is out of scope
-                // for this issue.
                 continue;
             }
         }
@@ -541,7 +559,7 @@ mod tests {
         let (_, args, redirect) = parse(b"echo hello > out.txt");
         assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some");
-        assert_eq!(redirect.unwrap().target, "out.txt");
+        assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
     }
 
     #[test]
@@ -549,7 +567,19 @@ mod tests {
         let (_, args, redirect) = parse(b"echo hello 1> out.txt");
         assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some for 1>");
-        assert_eq!(redirect.unwrap().target, "out.txt");
+        assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
+    }
+
+    #[test]
+    fn test_parse_redirect_trailing_operator_kept_as_arg() {
+        // A trailing `>` with no following filename should be preserved as a literal argument.
+        let (_, args, redirect) = parse(b"echo >");
+        assert!(redirect.is_none(), "no redirect target means no Redirect");
+        assert_eq!(
+            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec![">"],
+            "trailing `>` should be kept as a literal arg"
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,11 +7,21 @@ use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
+use crate::redirect::Redirect;
 
-/// Parse a raw input line into a [`Command`] and its argument list.
-pub fn parse(buffer: &[u8]) -> (Command, Args) {
-    let (command, args) = split_command_and_args(buffer);
+/// Parse a raw input line into a [`Command`], its argument list, and an optional
+/// stdout [`Redirect`].
+///
+/// If the line contains `>` or `1>` followed by a filename, that operator and
+/// the filename are stripped from the argument list and returned as a
+/// [`Redirect`].  Only unquoted redirect operators are recognised; a `>`
+/// that appears inside quotes is treated as a literal argument character.
+pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>) {
+    let (command, raw_args) = split_command_and_args(buffer);
     let command = parse_command(&command);
+
+    let (args, redirect) = extract_redirect(raw_args);
+
     let args = args
         .into_iter()
         .map(|(bytes, style)| match style {
@@ -19,7 +29,41 @@ pub fn parse(buffer: &[u8]) -> (Command, Args) {
             style => Arg::Quoted { bytes, style },
         })
         .collect();
-    (command, args)
+    (command, args, redirect)
+}
+
+/// Scan `raw_args` for an unquoted `>` or `1>` redirect operator.
+///
+/// Returns the remaining argument list (with the operator and its target
+/// filename removed) and an optional [`Redirect`].  The *last* redirect
+/// operator wins if multiple appear (matches bash behaviour).
+fn extract_redirect(
+    raw_args: Vec<(Vec<u8>, QuoteStyle)>,
+) -> (Vec<(Vec<u8>, QuoteStyle)>, Option<Redirect>) {
+    let mut out_args: Vec<(Vec<u8>, QuoteStyle)> = Vec::new();
+    let mut redirect: Option<Redirect> = None;
+
+    let mut iter = raw_args.into_iter().peekable();
+    while let Some((bytes, style)) = iter.next() {
+        // Only treat unquoted tokens as potential redirect operators.
+        if style == QuoteStyle::None {
+            let token = &bytes[..];
+            if token == b">" || token == b"1>" {
+                // The next token is the redirect target.
+                if let Some((target_bytes, _)) = iter.next() {
+                    let target = String::from_utf8_lossy(&target_bytes).into_owned();
+                    redirect = Some(Redirect::new(target));
+                }
+                // If there is no next token we silently drop the operator; a
+                // real shell would error, but error handling is out of scope
+                // for this issue.
+                continue;
+            }
+        }
+        out_args.push((bytes, style));
+    }
+
+    (out_args, redirect)
 }
 
 /// Split the trimmed input buffer into a command token and zero or more argument tokens.
@@ -488,5 +532,33 @@ mod tests {
         // 'a'"b" mixes single and double → QuoteStyle::None
         let (_, args) = split_styled(b"echo 'a'\"b\"");
         assert_eq!(args, vec![(b"ab".to_vec(), QuoteStyle::None)]);
+    }
+
+    // --- Redirect extraction tests ---
+
+    #[test]
+    fn test_parse_redirect_gt() {
+        let (_, args, redirect) = parse(b"echo hello > out.txt");
+        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        assert!(redirect.is_some(), "redirect should be Some");
+        assert_eq!(redirect.unwrap().target, "out.txt");
+    }
+
+    #[test]
+    fn test_parse_redirect_1gt() {
+        let (_, args, redirect) = parse(b"echo hello 1> out.txt");
+        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        assert!(redirect.is_some(), "redirect should be Some for 1>");
+        assert_eq!(redirect.unwrap().target, "out.txt");
+    }
+
+    #[test]
+    fn test_parse_no_redirect() {
+        let (_, args, redirect) = parse(b"echo hello world");
+        assert_eq!(
+            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello", "world"]
+        );
+        assert!(redirect.is_none());
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,0 +1,18 @@
+/// Stdout redirection target extracted from a command line.
+///
+/// When the parser encounters `>` or `1>` followed by a filename, it records
+/// the target here and removes the operator tokens from the argument list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Redirect {
+    /// Path to the file that should receive the command's standard output.
+    pub target: String,
+}
+
+impl Redirect {
+    /// Create a new stdout redirect targeting `target`.
+    pub fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -5,12 +5,12 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Redirect {
     /// Path to the file that should receive the command's standard output.
-    pub target: String,
+    pub target: std::path::PathBuf,
 }
 
 impl Redirect {
     /// Create a new stdout redirect targeting `target`.
-    pub fn new(target: impl Into<String>) -> Self {
+    pub fn new(target: impl Into<std::path::PathBuf>) -> Self {
         Self {
             target: target.into(),
         }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,6 +10,7 @@ use crate::{
     exit::ExitCode,
     io::{ShellIo, StandardIo},
     parser,
+    redirect::Redirect,
 };
 
 /// The ferrish shell REPL.
@@ -72,8 +73,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args) = parser::parse(buffer);
-            match self.execute_command(command.clone(), args) {
+            let (command, args, redirect) = parser::parse(buffer);
+            match self.execute_command(command.clone(), args, redirect) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
@@ -100,8 +101,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args) = parser::parse(buffer);
-            if let Some(exit_code) = self.execute_command(command, args)? {
+            let (command, args, redirect) = parser::parse(buffer);
+            if let Some(exit_code) = self.execute_command(command, args, redirect)? {
                 return Ok(exit_code);
             }
         }
@@ -114,8 +115,9 @@ impl<IO: ShellIo> Shell<IO> {
         &mut self,
         command: Command,
         args: Args,
+        redirect: Option<Redirect>,
     ) -> ShellResult<Option<ExitCode>> {
-        executor::execute(command, args, &mut *self.io.borrow_mut(), &mut self.ctx)
+        executor::execute(command, args, &mut *self.io.borrow_mut(), &mut self.ctx, redirect)
     }
 }
 
@@ -214,7 +216,7 @@ mod tests {
             ),
         );
         let args = vec![Arg::from("test"), Arg::from("message")];
-        let result = shell.execute_command(command, args);
+        let result = shell.execute_command(command, args, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
         {
@@ -233,7 +235,7 @@ mod tests {
                 crate::command::builtin::BuiltInName::Exit,
             ),
         );
-        let result = shell.execute_command(command, vec![]);
+        let result = shell.execute_command(command, vec![], None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(ExitCode::SUCCESS));
     }

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -108,8 +108,15 @@ impl ShellTest {
             })
             .0;
 
-        TestResult { output, error, home_dir: self.home_dir, exit_code }
-        // self drops here — temp_dir is cleaned up
+        TestResult {
+            output,
+            error,
+            home_dir: self.home_dir,
+            exit_code,
+            // Keep the TempDir alive so callers can inspect files written during
+            // the shell session before the directory is cleaned up on drop.
+            _temp_dir: self.temp_dir,
+        }
     }
 }
 
@@ -121,6 +128,9 @@ pub struct TestResult {
     home_dir: Option<PathBuf>,
     #[allow(dead_code)]
     exit_code: u8,
+    /// Keeps the isolated home temp directory alive for the lifetime of this result.
+    #[allow(dead_code)]
+    _temp_dir: Option<tempfile::TempDir>,
 }
 
 impl TestResult {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -99,6 +99,30 @@ fn test_no_redirect_goes_to_stdout() {
     );
 }
 
+/// Redirect should work for external executables, not just builtins.
+/// Uses `cat` (a PATH-resolved executable, not a ferrish builtin) to verify
+/// that the threaded stdout drain/write path correctly routes output to the
+/// redirect file rather than the terminal.
+#[cfg(unix)]
+#[test]
+fn test_redirect_external_executable_stdout_goes_to_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("input.txt", "extout\n")
+        .script("cat input.txt > out.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("extout"),
+        "external executable stdout should not appear on terminal when redirected"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should have been created by redirect");
+    assert_eq!(contents, "extout\n");
+}
+
 /// After a redirect command, the next command (without redirect) still goes to stdout.
 #[test]
 fn test_redirect_does_not_persist_to_next_command() {

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,0 +1,123 @@
+mod harness;
+
+use harness::ShellTest;
+
+// ============================================================================
+// Stdout redirection (> and 1>) integration tests
+// ============================================================================
+
+/// `echo hello > out.txt` should create the file containing "hello\n" and
+/// the text "hello" should NOT appear in terminal stdout.
+#[test]
+fn test_redirect_creates_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo hello > out.txt")
+        .run();
+
+    // "hello" should have gone to the file, not to terminal stdout.
+    assert!(
+        !result.output_contains("hello"),
+        "redirected output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should have been created by redirect");
+    assert_eq!(contents, "hello\n");
+}
+
+/// `1>` is equivalent to `>`.
+#[test]
+fn test_redirect_1gt_equivalent_to_gt() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo world 1> out.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("world"),
+        "redirected output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should have been created by 1>");
+    assert_eq!(contents, "world\n");
+}
+
+/// A second redirect to the same file should overwrite (not append) it.
+#[test]
+fn test_redirect_overwrites_existing_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("existing.txt", "old content\n")
+        .script("echo new content > existing.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("new content"),
+        "redirected output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("existing.txt"))
+        .expect("existing.txt should still exist");
+    assert_eq!(contents, "new content\n");
+}
+
+/// Multiple words are written as a single space-separated line (standard echo behaviour).
+#[test]
+fn test_redirect_multi_word_echo() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo foo bar baz > words.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("foo"),
+        "redirected output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("words.txt"))
+        .expect("words.txt should exist");
+    assert_eq!(contents, "foo bar baz\n");
+}
+
+/// Commands without a redirect still produce normal terminal output.
+#[test]
+fn test_no_redirect_goes_to_stdout() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo visible")
+        .run();
+
+    assert!(
+        result.output_contains("visible"),
+        "non-redirected echo should appear on stdout"
+    );
+}
+
+/// After a redirect command, the next command (without redirect) still goes to stdout.
+#[test]
+fn test_redirect_does_not_persist_to_next_command() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo first > first.txt\necho second")
+        .run();
+
+    // "second" should be on stdout; "first" should only be in the file.
+    assert!(
+        result.output_contains("second"),
+        "second echo should be on stdout"
+    );
+    assert!(
+        !result.output_contains("first"),
+        "first echo should not appear on stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("first.txt")).expect("first.txt");
+    assert_eq!(contents, "first\n");
+}


### PR DESCRIPTION
Implements `>` and `1>` stdout redirection by parsing the operator out of the argument list and routing the command's stdout to the named file (creating or overwriting it) while stderr continues to the terminal.

Key changes: a new `src/redirect.rs` module holds the `Redirect` struct; `parser.rs` gains `extract_redirect` which strips unquoted `>`/`1>` tokens; `executor.rs` opens the target file when a redirect is present and dispatches through a shared `execute_with_writers(out, err)` path for both redirected and normal cases; `io.rs` adds a `writers()` method to `ShellIo` so both writers can be borrowed simultaneously without a double-borrow; `tests/harness.rs` keeps the `TempDir` alive in `TestResult` so integration tests can inspect files written during the session; `tests/redirect.rs` covers `>`, `1>`, overwrite, multi-word args, no-redirect passthrough, and per-command scoping.

Closes #22