### PR TITLE
feat: stderr redirection (2>) operator

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,7 +13,7 @@ use crate::{
     exit::ExitCode,
     fs,
     io::ShellIo,
-    redirect::Redirect,
+    redirect::{Redirect, StderrRedirect},
 };
 
 enum CommandKind {
@@ -55,7 +55,9 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
 ///
 /// When `redirect` is `Some`, the command's standard output is written to the
 /// named file (creating or overwriting it) instead of the shell's normal
-/// stdout.  Standard error always goes to the shell's stderr stream.
+/// stdout.  When `stderr_redirect` is `Some`, the command's standard error is
+/// written to the named file instead of the shell's normal stderr.  Either,
+/// both, or neither redirect may be present independently.
 ///
 /// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
 pub fn execute(
@@ -64,20 +66,46 @@ pub fn execute(
     io: &mut impl ShellIo,
     ctx: &mut ShellCtx,
     redirect: Option<Redirect>,
+    stderr_redirect: Option<StderrRedirect>,
 ) -> ShellResult<Option<ExitCode>> {
-    if let Some(ref redir) = redirect {
-        // Resolve the redirect target path relative to the current working directory.
+    // Open the stdout redirect file if requested.
+    let mut stdout_file: Option<std::fs::File> = if let Some(ref redir) = redirect {
         let target_path = if redir.target.is_absolute() {
             redir.target.clone()
         } else {
             ctx.cwd.join(&redir.target)
         };
-
-        let mut file = std::fs::File::create(&target_path).map_err(ShellError::Io)?;
-        execute_with_writers(command, args, &mut file, io.err_writer(), ctx)
+        Some(std::fs::File::create(&target_path).map_err(ShellError::Io)?)
     } else {
-        let (out, err) = io.writers();
-        execute_with_writers(command, args, out, err, ctx)
+        None
+    };
+
+    // Open the stderr redirect file if requested.
+    let mut stderr_file: Option<std::fs::File> = if let Some(ref redir) = stderr_redirect {
+        let target_path = if redir.target.is_absolute() {
+            redir.target.clone()
+        } else {
+            ctx.cwd.join(&redir.target)
+        };
+        Some(std::fs::File::create(&target_path).map_err(ShellError::Io)?)
+    } else {
+        None
+    };
+
+    match (stdout_file.as_mut(), stderr_file.as_mut()) {
+        (Some(out_f), Some(err_f)) => {
+            execute_with_writers(command, args, out_f, err_f, ctx)
+        }
+        (Some(out_f), None) => {
+            execute_with_writers(command, args, out_f, io.err_writer(), ctx)
+        }
+        (None, Some(err_f)) => {
+            execute_with_writers(command, args, io.out_writer(), err_f, ctx)
+        }
+        (None, None) => {
+            let (out, err) = io.writers();
+            execute_with_writers(command, args, out, err, ctx)
+        }
     }
 }
 
@@ -298,6 +326,7 @@ mod tests {
             io,
             ctx,
             None,
+            None,
         )
     }
 
@@ -409,12 +438,36 @@ mod tests {
             &mut io,
             &mut ctx,
             redir,
+            None,
         );
         assert!(result.is_ok(), "execute with redirect should succeed: {result:?}");
         // stdout (io.output) should be empty — echo went to the file.
         assert_eq!(io.output(), b"", "terminal stdout should be empty");
         let contents = std::fs::read_to_string(&target).expect("redirect file");
         assert_eq!(contents, "hello\n");
+    }
+
+    #[test]
+    fn test_execute_with_stderr_redirect_writes_to_file() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let err_target = dir.path().join("err.txt");
+        let mut ctx = ShellCtx::new(None, dir.path().to_path_buf());
+        let mut io = MockIo::empty();
+        // exit with invalid argument writes to stderr
+        let stderr_redir = Some(crate::redirect::StderrRedirect::new(err_target.clone()));
+        let result = execute(
+            Command::BuiltIn(BuiltInCommand::new(BuiltInName::Exit)),
+            vec![Arg::from("notanumber")],
+            &mut io,
+            &mut ctx,
+            None,
+            stderr_redir,
+        );
+        assert!(result.is_ok(), "execute with stderr redirect should succeed: {result:?}");
+        // io.error() (terminal stderr) should be empty — error went to the file.
+        assert_eq!(io.error(), b"", "terminal stderr should be empty");
+        let contents = std::fs::read_to_string(&err_target).expect("stderr redirect file");
+        assert!(contents.contains("numeric argument required"), "expected error in file: {contents}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod fs;
 pub mod io;
 /// Input parsing: splits raw bytes into a command and its arguments.
 pub mod parser;
-/// Stdout redirection descriptors produced by the parser.
+/// I/O redirection descriptors produced by the parser.
 pub mod redirect;
 /// The interactive REPL shell.
 pub mod shell;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,6 +92,10 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
                         String::from_utf8_lossy(&target_bytes).as_ref(),
                     );
                     stderr_redirect = Some(StderrRedirect::new(target));
+                } else {
+                    // No filename follows the operator — keep it as a literal
+                    // argument rather than silently dropping it.
+                    out_args.push((bytes, style));
                 }
                 continue;
             }
@@ -608,6 +612,18 @@ mod tests {
             args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
             vec![">"],
             "trailing `>` should be kept as a literal arg"
+        );
+    }
+
+    #[test]
+    fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
+        // A trailing `2>` with no following filename should be preserved as a literal argument.
+        let (_, args, _, stderr_redirect) = parse(b"echo 2>");
+        assert!(stderr_redirect.is_none(), "no redirect target means no StderrRedirect");
+        assert_eq!(
+            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec!["2>"],
+            "trailing `2>` should be kept as a literal arg"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,20 +7,23 @@ use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
-use crate::redirect::Redirect;
+use crate::redirect::{Redirect, StderrRedirect};
 
-/// Parse a raw input line into a [`Command`], its argument list, and an optional
-/// stdout [`Redirect`].
+/// Parse a raw input line into a [`Command`], its argument list, an optional
+/// stdout [`Redirect`], and an optional stderr [`StderrRedirect`].
 ///
 /// If the line contains `>` or `1>` followed by a filename, that operator and
 /// the filename are stripped from the argument list and returned as a
-/// [`Redirect`].  Only unquoted redirect operators are recognised; a `>`
-/// that appears inside quotes is treated as a literal argument character.
-pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>) {
+/// [`Redirect`].  If the line contains `2>` followed by a filename, that
+/// operator and the filename are returned as a [`StderrRedirect`].
+///
+/// Only unquoted redirect operators are recognised; an operator character that
+/// appears inside quotes is treated as a literal argument character.
+pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>, Option<StderrRedirect>) {
     let (command, raw_args) = split_command_and_args(buffer);
     let command = parse_command(&command);
 
-    let (args, redirect) = extract_redirect(raw_args);
+    let (args, redirect, stderr_redirect) = extract_redirects(raw_args);
 
     let args = args
         .into_iter()
@@ -29,17 +32,23 @@ pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>) {
             style => Arg::Quoted { bytes, style },
         })
         .collect();
-    (command, args, redirect)
+    (command, args, redirect, stderr_redirect)
 }
 
-/// Scan `raw_args` for an unquoted `>` or `1>` redirect operator.
+/// Raw argument token: byte content and its quoting style.
+type RawArg = (Vec<u8>, QuoteStyle);
+
+/// Result of redirect extraction: remaining args, optional stdout redirect, optional stderr redirect.
+type ExtractResult = (Vec<RawArg>, Option<Redirect>, Option<StderrRedirect>);
+
+/// Scan `raw_args` for unquoted redirect operators (`>`, `1>`, `2>`).
 ///
-/// Returns the remaining argument list (with the operator and its target
-/// filename removed) and an optional [`Redirect`]. If multiple redirect
-/// operators appear, only the last one is returned; earlier redirect
-/// operators are stripped from the argument list but do not trigger
-/// intermediate bash-style side effects such as creating or truncating
-/// their targets.
+/// Returns the remaining argument list (with operators and their target
+/// filenames removed), an optional stdout [`Redirect`], and an optional
+/// stderr [`StderrRedirect`]. If multiple operators of the same kind appear,
+/// only the last one is returned; earlier ones are stripped from the argument
+/// list but do not trigger intermediate bash-style side effects such as
+/// creating or truncating their targets.
 ///
 /// When a redirect operator appears without a following filename token (e.g.
 /// a trailing `>`), the operator is kept as a normal argument rather than
@@ -51,12 +60,11 @@ pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>) {
 /// *and* mixed-quoting contexts (e.g. `1'>'`), so a mixed token whose bytes
 /// happen to be `1>` would also be recognised as a redirect operator.
 /// Distinguishing the two cases would require a dedicated `QuoteStyle::Mixed`
-/// variant; that is left for a future quoting-improvements pass.
-fn extract_redirect(
-    raw_args: Vec<(Vec<u8>, QuoteStyle)>,
-) -> (Vec<(Vec<u8>, QuoteStyle)>, Option<Redirect>) {
-    let mut out_args: Vec<(Vec<u8>, QuoteStyle)> = Vec::new();
+/// variant; that is tracked in issue #85.
+fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
+    let mut out_args: Vec<RawArg> = Vec::new();
     let mut redirect: Option<Redirect> = None;
+    let mut stderr_redirect: Option<StderrRedirect> = None;
 
     let mut iter = raw_args.into_iter().peekable();
     while let Some((bytes, style)) = iter.next() {
@@ -77,11 +85,21 @@ fn extract_redirect(
                 }
                 continue;
             }
+            if token == b"2>" {
+                // The next token is the stderr redirect target.
+                if let Some((target_bytes, _)) = iter.next() {
+                    let target = std::path::PathBuf::from(
+                        String::from_utf8_lossy(&target_bytes).as_ref(),
+                    );
+                    stderr_redirect = Some(StderrRedirect::new(target));
+                }
+                continue;
+            }
         }
         out_args.push((bytes, style));
     }
 
-    (out_args, redirect)
+    (out_args, redirect, stderr_redirect)
 }
 
 /// Split the trimmed input buffer into a command token and zero or more argument tokens.
@@ -556,24 +574,35 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, redirect) = parse(b"echo hello > out.txt");
+        let (_, args, redirect, stderr_redirect) = parse(b"echo hello > out.txt");
         assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
+        assert!(stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, redirect) = parse(b"echo hello 1> out.txt");
+        let (_, args, redirect, stderr_redirect) = parse(b"echo hello 1> out.txt");
         assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some for 1>");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
+        assert!(stderr_redirect.is_none());
+    }
+
+    #[test]
+    fn test_parse_redirect_2gt() {
+        let (_, args, redirect, stderr_redirect) = parse(b"echo hello 2> err.txt");
+        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        assert!(redirect.is_none(), "stdout redirect should be None for 2>");
+        assert!(stderr_redirect.is_some(), "stderr redirect should be Some for 2>");
+        assert_eq!(stderr_redirect.unwrap().target, std::path::PathBuf::from("err.txt"));
     }
 
     #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
         // A trailing `>` with no following filename should be preserved as a literal argument.
-        let (_, args, redirect) = parse(b"echo >");
+        let (_, args, redirect, _) = parse(b"echo >");
         assert!(redirect.is_none(), "no redirect target means no Redirect");
         assert_eq!(
             args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
@@ -584,11 +613,12 @@ mod tests {
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, redirect) = parse(b"echo hello world");
+        let (_, args, redirect, stderr_redirect) = parse(b"echo hello world");
         assert_eq!(
             args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]
         );
         assert!(redirect.is_none());
+        assert!(stderr_redirect.is_none());
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -16,3 +16,23 @@ impl Redirect {
         }
     }
 }
+
+/// Stderr redirection target extracted from a command line.
+///
+/// When the parser encounters `2>` followed by a filename, it records the
+/// target here and removes the operator tokens from the argument list.
+/// Standard output is unaffected and continues to go to the terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StderrRedirect {
+    /// Path to the file that should receive the command's standard error.
+    pub target: std::path::PathBuf,
+}
+
+impl StderrRedirect {
+    /// Create a new stderr redirect targeting `target`.
+    pub fn new(target: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,7 +10,7 @@ use crate::{
     exit::ExitCode,
     io::{ShellIo, StandardIo},
     parser,
-    redirect::Redirect,
+    redirect::{Redirect, StderrRedirect},
 };
 
 /// The ferrish shell REPL.
@@ -73,8 +73,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect) = parser::parse(buffer);
-            match self.execute_command(command.clone(), args, redirect) {
+            let (command, args, redirect, stderr_redirect) = parser::parse(buffer);
+            match self.execute_command(command.clone(), args, redirect, stderr_redirect) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
@@ -101,8 +101,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect) = parser::parse(buffer);
-            if let Some(exit_code) = self.execute_command(command, args, redirect)? {
+            let (command, args, redirect, stderr_redirect) = parser::parse(buffer);
+            if let Some(exit_code) = self.execute_command(command, args, redirect, stderr_redirect)? {
                 return Ok(exit_code);
             }
         }
@@ -116,8 +116,9 @@ impl<IO: ShellIo> Shell<IO> {
         command: Command,
         args: Args,
         redirect: Option<Redirect>,
+        stderr_redirect: Option<StderrRedirect>,
     ) -> ShellResult<Option<ExitCode>> {
-        executor::execute(command, args, &mut *self.io.borrow_mut(), &mut self.ctx, redirect)
+        executor::execute(command, args, &mut *self.io.borrow_mut(), &mut self.ctx, redirect, stderr_redirect)
     }
 }
 
@@ -216,7 +217,7 @@ mod tests {
             ),
         );
         let args = vec![Arg::from("test"), Arg::from("message")];
-        let result = shell.execute_command(command, args, None);
+        let result = shell.execute_command(command, args, None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
         {
@@ -235,7 +236,7 @@ mod tests {
                 crate::command::builtin::BuiltInName::Exit,
             ),
         );
-        let result = shell.execute_command(command, vec![], None);
+        let result = shell.execute_command(command, vec![], None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(ExitCode::SUCCESS));
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -145,3 +145,104 @@ fn test_redirect_does_not_persist_to_next_command() {
     let contents = std::fs::read_to_string(home.join("first.txt")).expect("first.txt");
     assert_eq!(contents, "first\n");
 }
+
+// ============================================================================
+// Stderr redirection (2>) integration tests
+// ============================================================================
+
+/// `exit notanumber 2> err.txt` should write the error message to the file
+/// and NOT to the terminal stderr.
+#[test]
+fn test_stderr_redirect_creates_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("exit notanumber 2> err.txt")
+        .run();
+
+    // Error message should have gone to the file, not to terminal stderr.
+    assert!(
+        !result.error().contains("numeric argument required"),
+        "redirected stderr must not appear on terminal stderr"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should have been created by 2> redirect");
+    assert!(
+        contents.contains("numeric argument required"),
+        "expected error message in redirect file, got: {contents}"
+    );
+}
+
+/// `2>` should capture only stderr; stdout should still reach the terminal.
+#[test]
+fn test_stderr_redirect_stdout_still_goes_to_terminal() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo visible 2> err.txt")
+        .run();
+
+    // Stdout (echo output) should still appear on terminal.
+    assert!(
+        result.output_contains("visible"),
+        "stdout should still go to terminal when only stderr is redirected"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let err_file = home.join("err.txt");
+    // File should exist (created on open) and be empty (echo writes nothing to stderr).
+    let contents = std::fs::read_to_string(&err_file)
+        .expect("err.txt should have been created by 2>");
+    assert!(
+        contents.is_empty(),
+        "stderr redirect file should be empty when no errors occur: {contents}"
+    );
+}
+
+/// A second `2>` redirect to the same file should overwrite (not append) it.
+#[test]
+fn test_stderr_redirect_overwrites_existing_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("err.txt", "old content\n")
+        .script("exit notanumber 2> err.txt")
+        .run();
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should exist after redirect");
+    assert!(
+        !contents.contains("old content"),
+        "redirect should have overwritten old content"
+    );
+    assert!(
+        contents.contains("numeric argument required"),
+        "new error message should be in file: {contents}"
+    );
+}
+
+/// A `2>` on one command should not affect stdout of a subsequent command.
+/// Stdout of the command following the stderr-redirect should still reach the terminal.
+#[test]
+fn test_stderr_redirect_does_not_affect_subsequent_stdout() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("exit notanumber 2> err.txt\necho after")
+        .run();
+
+    // `exit notanumber` exits with failure code, so `echo after` won't run.
+    // Instead verify: the `2>` file was created with the error, and terminal
+    // stderr from the `exit` error was empty (it went to the file).
+    assert!(
+        !result.error().contains("numeric argument required"),
+        "error written with 2> must not appear on terminal stderr"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should exist");
+    assert!(
+        contents.contains("numeric argument required"),
+        "error should be in the redirect file: {contents}"
+    );
+}

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -221,18 +221,14 @@ fn test_stderr_redirect_overwrites_existing_file() {
     );
 }
 
-/// A `2>` on one command should not affect stdout of a subsequent command.
-/// Stdout of the command following the stderr-redirect should still reach the terminal.
+/// `2>` captures a builtin's stderr output to a file and not to the terminal.
 #[test]
-fn test_stderr_redirect_does_not_affect_subsequent_stdout() {
+fn test_stderr_redirect_captures_builtin_error_to_file() {
     let result = ShellTest::new()
         .with_isolated_home()
-        .script("exit notanumber 2> err.txt\necho after")
+        .script("exit notanumber 2> err.txt")
         .run();
 
-    // `exit notanumber` exits with failure code, so `echo after` won't run.
-    // Instead verify: the `2>` file was created with the error, and terminal
-    // stderr from the `exit` error was empty (it went to the file).
     assert!(
         !result.error().contains("numeric argument required"),
         "error written with 2> must not appear on terminal stderr"
@@ -245,4 +241,28 @@ fn test_stderr_redirect_does_not_affect_subsequent_stdout() {
         contents.contains("numeric argument required"),
         "error should be in the redirect file: {contents}"
     );
+}
+
+/// A `2>` on one command does not affect stdout of a subsequent command.
+/// Uses `cat /nonexistent` which writes to stderr but is non-fatal (the shell
+/// continues after reporting the non-zero exit), so `echo after` still runs.
+#[cfg(unix)]
+#[test]
+fn test_stderr_redirect_does_not_affect_subsequent_stdout() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("cat /nonexistent 2> err.txt\necho after")
+        .run();
+
+    // `echo after` must have run and reached terminal stdout.
+    assert!(
+        result.output_contains("after"),
+        "stdout of subsequent command must reach the terminal"
+    );
+
+    // cat's stderr should be in the file, not the terminal.
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should exist");
+    assert!(!contents.is_empty(), "cat's stderr should have been captured to file");
 }


### PR DESCRIPTION
Adds `2>` stderr redirection by extending `src/redirect.rs` with a `StderrRedirect` struct (parallel to the existing `Redirect` for stdout); `parser.rs` gains recognition of unquoted `2>` tokens in `extract_redirects`, stripping the operator and target filename from the argument list; `executor.rs` opens the target file when a stderr redirect is present and passes it as the `err` writer to `execute_with_writers`, while stdout continues to the terminal. Both `>` and `2>` may appear independently on the same command line. New unit tests cover the parser's `2>` recognition and the executor's file-routing behaviour; new integration tests in `tests/redirect.rs` verify file creation, overwrite semantics, stdout passthrough, and that redirected stderr does not leak to the terminal.

Closes #23