### PR TITLE
feat: append stdout redirection (>>) operator

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,7 +13,7 @@ use crate::{
     exit::ExitCode,
     fs,
     io::ShellIo,
-    redirect::{Redirect, StderrRedirect},
+    redirect::{Redirect, RedirectAppend, StderrRedirect},
 };
 
 enum CommandKind {
@@ -55,9 +55,14 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
 ///
 /// When `redirect` is `Some`, the command's standard output is written to the
 /// named file (creating or overwriting it) instead of the shell's normal
-/// stdout.  When `stderr_redirect` is `Some`, the command's standard error is
-/// written to the named file instead of the shell's normal stderr.  Either,
-/// both, or neither redirect may be present independently.
+/// stdout.  When `redirect_append` is `Some`, the command's standard output is
+/// appended to the named file (creating it if it does not exist) instead of
+/// the shell's normal stdout.  When `stderr_redirect` is `Some`, the command's
+/// standard error is written to the named file instead of the shell's normal
+/// stderr.  Any combination of redirects may be present independently.
+///
+/// If both `redirect` and `redirect_append` are `Some`, `redirect` takes
+/// precedence (truncate wins over append for the same command invocation).
 ///
 /// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
 pub fn execute(
@@ -66,9 +71,10 @@ pub fn execute(
     io: &mut impl ShellIo,
     ctx: &mut ShellCtx,
     redirect: Option<Redirect>,
+    redirect_append: Option<RedirectAppend>,
     stderr_redirect: Option<StderrRedirect>,
 ) -> ShellResult<Option<ExitCode>> {
-    // Open the stdout redirect file if requested.
+    // Open the stdout redirect file if requested (truncate takes precedence over append).
     let mut stdout_file: Option<std::fs::File> = if let Some(ref redir) = redirect {
         let target_path = if redir.target.is_absolute() {
             redir.target.clone()
@@ -76,6 +82,19 @@ pub fn execute(
             ctx.cwd.join(&redir.target)
         };
         Some(std::fs::File::create(&target_path).map_err(ShellError::Io)?)
+    } else if let Some(ref redir) = redirect_append {
+        let target_path = if redir.target.is_absolute() {
+            redir.target.clone()
+        } else {
+            ctx.cwd.join(&redir.target)
+        };
+        Some(
+            std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&target_path)
+                .map_err(ShellError::Io)?,
+        )
     } else {
         None
     };
@@ -327,6 +346,7 @@ mod tests {
             ctx,
             None,
             None,
+            None,
         )
     }
 
@@ -439,6 +459,7 @@ mod tests {
             &mut ctx,
             redir,
             None,
+            None,
         );
         assert!(result.is_ok(), "execute with redirect should succeed: {result:?}");
         // stdout (io.output) should be empty — echo went to the file.
@@ -460,6 +481,7 @@ mod tests {
             vec![Arg::from("notanumber")],
             &mut io,
             &mut ctx,
+            None,
             None,
             stderr_redir,
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,23 +7,34 @@ use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
-use crate::redirect::{Redirect, StderrRedirect};
+use crate::redirect::{Redirect, RedirectAppend, StderrRedirect};
 
 /// Parse a raw input line into a [`Command`], its argument list, an optional
-/// stdout [`Redirect`], and an optional stderr [`StderrRedirect`].
+/// stdout [`Redirect`], an optional stdout append [`RedirectAppend`], and an
+/// optional stderr [`StderrRedirect`].
 ///
 /// If the line contains `>` or `1>` followed by a filename, that operator and
 /// the filename are stripped from the argument list and returned as a
-/// [`Redirect`].  If the line contains `2>` followed by a filename, that
-/// operator and the filename are returned as a [`StderrRedirect`].
+/// [`Redirect`].  If the line contains `>>` followed by a filename, it is
+/// returned as a [`RedirectAppend`] (existing content preserved).  If the
+/// line contains `2>` followed by a filename, that operator and the filename
+/// are returned as a [`StderrRedirect`].
 ///
 /// Only unquoted redirect operators are recognised; an operator character that
 /// appears inside quotes is treated as a literal argument character.
-pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>, Option<StderrRedirect>) {
+pub fn parse(
+    buffer: &[u8],
+) -> (
+    Command,
+    Args,
+    Option<Redirect>,
+    Option<RedirectAppend>,
+    Option<StderrRedirect>,
+) {
     let (command, raw_args) = split_command_and_args(buffer);
     let command = parse_command(&command);
 
-    let (args, redirect, stderr_redirect) = extract_redirects(raw_args);
+    let (args, redirect, redirect_append, stderr_redirect) = extract_redirects(raw_args);
 
     let args = args
         .into_iter()
@@ -32,26 +43,33 @@ pub fn parse(buffer: &[u8]) -> (Command, Args, Option<Redirect>, Option<StderrRe
             style => Arg::Quoted { bytes, style },
         })
         .collect();
-    (command, args, redirect, stderr_redirect)
+    (command, args, redirect, redirect_append, stderr_redirect)
 }
 
 /// Raw argument token: byte content and its quoting style.
 type RawArg = (Vec<u8>, QuoteStyle);
 
-/// Result of redirect extraction: remaining args, optional stdout redirect, optional stderr redirect.
-type ExtractResult = (Vec<RawArg>, Option<Redirect>, Option<StderrRedirect>);
+/// Result of redirect extraction: remaining args, optional stdout redirect,
+/// optional stdout append redirect, and optional stderr redirect.
+type ExtractResult = (
+    Vec<RawArg>,
+    Option<Redirect>,
+    Option<RedirectAppend>,
+    Option<StderrRedirect>,
+);
 
-/// Scan `raw_args` for unquoted redirect operators (`>`, `1>`, `2>`).
+/// Scan `raw_args` for unquoted redirect operators (`>`, `1>`, `>>`, `2>`).
 ///
 /// Returns the remaining argument list (with operators and their target
-/// filenames removed), an optional stdout [`Redirect`], and an optional
-/// stderr [`StderrRedirect`]. If multiple operators of the same kind appear,
-/// only the last one is returned; earlier ones are stripped from the argument
-/// list but do not trigger intermediate bash-style side effects such as
-/// creating or truncating their targets.
+/// filenames removed), an optional stdout [`Redirect`], an optional stdout
+/// append [`RedirectAppend`], and an optional stderr [`StderrRedirect`]. If
+/// multiple operators of the same kind appear, only the last one is returned;
+/// earlier ones are stripped from the argument list but do not trigger
+/// intermediate bash-style side effects such as creating or truncating their
+/// targets.
 ///
 /// When a redirect operator appears without a following filename token (e.g.
-/// a trailing `>`), the operator is kept as a normal argument rather than
+/// a trailing `>>`), the operator is kept as a normal argument rather than
 /// silently dropped.
 ///
 /// # Quoting caveat
@@ -64,6 +82,7 @@ type ExtractResult = (Vec<RawArg>, Option<Redirect>, Option<StderrRedirect>);
 fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
     let mut out_args: Vec<RawArg> = Vec::new();
     let mut redirect: Option<Redirect> = None;
+    let mut redirect_append: Option<RedirectAppend> = None;
     let mut stderr_redirect: Option<StderrRedirect> = None;
 
     let mut iter = raw_args.into_iter().peekable();
@@ -71,6 +90,20 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
         // Only treat unquoted tokens as potential redirect operators.
         if style == QuoteStyle::None {
             let token = &bytes[..];
+            if token == b">>" {
+                // The next token is the append redirect target.
+                if let Some((target_bytes, _)) = iter.next() {
+                    let target = std::path::PathBuf::from(
+                        String::from_utf8_lossy(&target_bytes).as_ref(),
+                    );
+                    redirect_append = Some(RedirectAppend::new(target));
+                } else {
+                    // No filename follows the operator — keep it as a literal
+                    // argument rather than silently dropping it.
+                    out_args.push((bytes, style));
+                }
+                continue;
+            }
             if token == b">" || token == b"1>" {
                 // The next token is the redirect target.
                 if let Some((target_bytes, _)) = iter.next() {
@@ -103,7 +136,7 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
         out_args.push((bytes, style));
     }
 
-    (out_args, redirect, stderr_redirect)
+    (out_args, redirect, redirect_append, stderr_redirect)
 }
 
 /// Split the trimmed input buffer into a command token and zero or more argument tokens.
@@ -578,50 +611,81 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, redirect, stderr_redirect) = parse(b"echo hello > out.txt");
-        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello > out.txt");
+        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
+        assert!(redirect_append.is_none());
         assert!(stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, redirect, stderr_redirect) = parse(b"echo hello 1> out.txt");
-        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello 1> out.txt");
+        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some for 1>");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
+        assert!(redirect_append.is_none());
         assert!(stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_2gt() {
-        let (_, args, redirect, stderr_redirect) = parse(b"echo hello 2> err.txt");
-        assert_eq!(args.iter().map(|a| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello 2> err.txt");
+        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_none(), "stdout redirect should be None for 2>");
+        assert!(redirect_append.is_none());
         assert!(stderr_redirect.is_some(), "stderr redirect should be Some for 2>");
         assert_eq!(stderr_redirect.unwrap().target, std::path::PathBuf::from("err.txt"));
     }
 
     #[test]
+    fn test_parse_redirect_gtgt() {
+        let (_, args, redirect, redirect_append, stderr_redirect) =
+            parse(b"echo hello >> out.txt");
+        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        assert!(redirect.is_none(), "stdout truncate redirect should be None for >>");
+        assert!(redirect_append.is_some(), "append redirect should be Some for >>");
+        assert_eq!(
+            redirect_append.unwrap().target,
+            std::path::PathBuf::from("out.txt")
+        );
+        assert!(stderr_redirect.is_none());
+    }
+
+    #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
         // A trailing `>` with no following filename should be preserved as a literal argument.
-        let (_, args, redirect, _) = parse(b"echo >");
+        let (_, args, redirect, redirect_append, _) = parse(b"echo >");
         assert!(redirect.is_none(), "no redirect target means no Redirect");
+        assert!(redirect_append.is_none());
         assert_eq!(
-            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec![">"],
             "trailing `>` should be kept as a literal arg"
         );
     }
 
     #[test]
+    fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
+        // A trailing `>>` with no following filename should be preserved as a literal argument.
+        let (_, args, redirect, redirect_append, _) = parse(b"echo >>");
+        assert!(redirect.is_none());
+        assert!(redirect_append.is_none(), "no redirect target means no RedirectAppend");
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec![">>"],
+            "trailing `>>` should be kept as a literal arg"
+        );
+    }
+
+    #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
         // A trailing `2>` with no following filename should be preserved as a literal argument.
-        let (_, args, _, stderr_redirect) = parse(b"echo 2>");
+        let (_, args, _, _, stderr_redirect) = parse(b"echo 2>");
         assert!(stderr_redirect.is_none(), "no redirect target means no StderrRedirect");
         assert_eq!(
-            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["2>"],
             "trailing `2>` should be kept as a literal arg"
         );
@@ -629,12 +693,13 @@ mod tests {
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, redirect, stderr_redirect) = parse(b"echo hello world");
+        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello world");
         assert_eq!(
-            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]
         );
         assert!(redirect.is_none());
+        assert!(redirect_append.is_none());
         assert!(stderr_redirect.is_none());
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -17,6 +17,27 @@ impl Redirect {
     }
 }
 
+/// Stdout append-redirection target extracted from a command line.
+///
+/// When the parser encounters `>>` followed by a filename, it records the
+/// target here and removes the operator tokens from the argument list.
+/// Unlike [`Redirect`], existing file content is preserved — new output is
+/// appended at the end.  If the file does not exist it is created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedirectAppend {
+    /// Path to the file that should receive appended standard output.
+    pub target: std::path::PathBuf,
+}
+
+impl RedirectAppend {
+    /// Create a new stdout append redirect targeting `target`.
+    pub fn new(target: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}
+
 /// Stderr redirection target extracted from a command line.
 ///
 /// When the parser encounters `2>` followed by a filename, it records the

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,7 +10,7 @@ use crate::{
     exit::ExitCode,
     io::{ShellIo, StandardIo},
     parser,
-    redirect::{Redirect, StderrRedirect},
+    redirect::{Redirect, RedirectAppend, StderrRedirect},
 };
 
 /// The ferrish shell REPL.
@@ -73,8 +73,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect, stderr_redirect) = parser::parse(buffer);
-            match self.execute_command(command.clone(), args, redirect, stderr_redirect) {
+            let (command, args, redirect, redirect_append, stderr_redirect) = parser::parse(buffer);
+            match self.execute_command(command.clone(), args, redirect, redirect_append, stderr_redirect) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
@@ -101,8 +101,8 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect, stderr_redirect) = parser::parse(buffer);
-            if let Some(exit_code) = self.execute_command(command, args, redirect, stderr_redirect)? {
+            let (command, args, redirect, redirect_append, stderr_redirect) = parser::parse(buffer);
+            if let Some(exit_code) = self.execute_command(command, args, redirect, redirect_append, stderr_redirect)? {
                 return Ok(exit_code);
             }
         }
@@ -116,9 +116,18 @@ impl<IO: ShellIo> Shell<IO> {
         command: Command,
         args: Args,
         redirect: Option<Redirect>,
+        redirect_append: Option<RedirectAppend>,
         stderr_redirect: Option<StderrRedirect>,
     ) -> ShellResult<Option<ExitCode>> {
-        executor::execute(command, args, &mut *self.io.borrow_mut(), &mut self.ctx, redirect, stderr_redirect)
+        executor::execute(
+            command,
+            args,
+            &mut *self.io.borrow_mut(),
+            &mut self.ctx,
+            redirect,
+            redirect_append,
+            stderr_redirect,
+        )
     }
 }
 
@@ -217,7 +226,7 @@ mod tests {
             ),
         );
         let args = vec![Arg::from("test"), Arg::from("message")];
-        let result = shell.execute_command(command, args, None, None);
+        let result = shell.execute_command(command, args, None, None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
         {
@@ -236,7 +245,7 @@ mod tests {
                 crate::command::builtin::BuiltInName::Exit,
             ),
         );
-        let result = shell.execute_command(command, vec![], None, None);
+        let result = shell.execute_command(command, vec![], None, None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(ExitCode::SUCCESS));
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -147,6 +147,96 @@ fn test_redirect_does_not_persist_to_next_command() {
 }
 
 // ============================================================================
+// Stdout append redirection (>>) integration tests
+// ============================================================================
+
+/// `echo line1 >> out.txt` on a new file should create it with "line1\n".
+#[test]
+fn test_append_redirect_creates_file_when_absent() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo line1 >> out.txt")
+        .run();
+
+    // "line1" should have gone to the file, not terminal stdout.
+    assert!(
+        !result.output_contains("line1"),
+        "appended output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should have been created by >>");
+    assert_eq!(contents, "line1\n");
+}
+
+/// A second `>>` to the same file appends rather than overwrites.
+#[test]
+fn test_append_redirect_preserves_existing_content() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("out.txt", "existing\n")
+        .script("echo appended >> out.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("appended"),
+        "appended output must not appear on terminal stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should still exist");
+    assert_eq!(contents, "existing\nappended\n");
+}
+
+/// Two consecutive `>>` commands accumulate lines in order.
+#[test]
+fn test_append_redirect_two_commands_accumulate() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo first >> acc.txt\necho second >> acc.txt")
+        .run();
+
+    assert!(
+        !result.output_contains("first"),
+        "redirected lines must not appear on stdout"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("acc.txt"))
+        .expect("acc.txt should exist");
+    assert_eq!(contents, "first\nsecond\n");
+}
+
+/// `>` on a file that already has content from `>>` should overwrite it.
+#[test]
+fn test_truncate_after_append_overwrites() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo appended >> out.txt\necho truncated > out.txt")
+        .run();
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("out.txt should exist");
+    assert_eq!(contents, "truncated\n");
+}
+
+/// A `>>` without a following filename should be kept as a literal argument
+/// (the operator token must not be silently dropped).
+#[test]
+fn test_append_redirect_trailing_operator_kept_as_arg() {
+    // echo >> with no filename — "echo" receives ">>" as its argument.
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo >>")
+        .run();
+
+    result.assert_output_contains(">>");
+}
+
+// ============================================================================
 // Stderr redirection (2>) integration tests
 // ============================================================================
 


### PR DESCRIPTION
Implements `>>` append stdout redirection by adding a `RedirectAppend` struct to `src/redirect.rs` (mirroring the existing `Redirect` pattern), extending `extract_redirects` in `src/parser.rs` to recognise the `>>` token (checked before `>` to avoid prefix ambiguity), opening the file via `OpenOptions::append(true).create(true)` in `src/executor.rs`, and threading the new `Option<RedirectAppend>` through `src/shell.rs`. Integration tests cover: file creation when absent, existing content preservation, multi-command accumulation, `>` overwriting after `>>`, and trailing `>>` without a target being passed through as a literal argument.

Closes #24