### PR TITLE
feat: stderr append redirection (2>>)

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,7 +13,7 @@ use crate::{
     exit::ExitCode,
     fs,
     io::ShellIo,
-    redirect::{Redirect, RedirectAppend, StderrRedirect},
+    redirect::{Redirect, RedirectAppend, StderrRedirect, StderrRedirectAppend},
 };
 
 enum CommandKind {
@@ -59,12 +59,18 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
 /// appended to the named file (creating it if it does not exist) instead of
 /// the shell's normal stdout.  When `stderr_redirect` is `Some`, the command's
 /// standard error is written to the named file instead of the shell's normal
-/// stderr.  Any combination of redirects may be present independently.
+/// stderr.  When `stderr_redirect_append` is `Some`, the command's standard
+/// error is appended to the named file (creating it if it does not exist).
+/// Any combination of redirects may be present independently.
 ///
 /// If both `redirect` and `redirect_append` are `Some`, `redirect` takes
 /// precedence (truncate wins over append for the same command invocation).
+/// Likewise, if both `stderr_redirect` and `stderr_redirect_append` are `Some`,
+/// `stderr_redirect` takes precedence.
 ///
 /// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
+// Issue #26 will consolidate these parameters into an ExecuteOptions struct.
+#[allow(clippy::too_many_arguments)]
 pub fn execute(
     command: Command,
     args: Args,
@@ -73,6 +79,7 @@ pub fn execute(
     redirect: Option<Redirect>,
     redirect_append: Option<RedirectAppend>,
     stderr_redirect: Option<StderrRedirect>,
+    stderr_redirect_append: Option<StderrRedirectAppend>,
 ) -> ShellResult<Option<ExitCode>> {
     // Open the stdout redirect file if requested (truncate takes precedence over append).
     let mut stdout_file: Option<std::fs::File> = if let Some(ref redir) = redirect {
@@ -99,7 +106,7 @@ pub fn execute(
         None
     };
 
-    // Open the stderr redirect file if requested.
+    // Open the stderr redirect file if requested (truncate takes precedence over append).
     let mut stderr_file: Option<std::fs::File> = if let Some(ref redir) = stderr_redirect {
         let target_path = if redir.target.is_absolute() {
             redir.target.clone()
@@ -107,6 +114,19 @@ pub fn execute(
             ctx.cwd.join(&redir.target)
         };
         Some(std::fs::File::create(&target_path).map_err(ShellError::Io)?)
+    } else if let Some(ref redir) = stderr_redirect_append {
+        let target_path = if redir.target.is_absolute() {
+            redir.target.clone()
+        } else {
+            ctx.cwd.join(&redir.target)
+        };
+        Some(
+            std::fs::OpenOptions::new()
+                .append(true)
+                .create(true)
+                .open(&target_path)
+                .map_err(ShellError::Io)?,
+        )
     } else {
         None
     };
@@ -347,6 +367,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -460,6 +481,7 @@ mod tests {
             redir,
             None,
             None,
+            None,
         );
         assert!(result.is_ok(), "execute with redirect should succeed: {result:?}");
         // stdout (io.output) should be empty — echo went to the file.
@@ -484,6 +506,7 @@ mod tests {
             None,
             None,
             stderr_redir,
+            None,
         );
         assert!(result.is_ok(), "execute with stderr redirect should succeed: {result:?}");
         // io.error() (terminal stderr) should be empty — error went to the file.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,18 +7,20 @@ use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
-use crate::redirect::{Redirect, RedirectAppend, StderrRedirect};
+use crate::redirect::{Redirect, RedirectAppend, StderrRedirect, StderrRedirectAppend};
 
 /// Parse a raw input line into a [`Command`], its argument list, an optional
-/// stdout [`Redirect`], an optional stdout append [`RedirectAppend`], and an
-/// optional stderr [`StderrRedirect`].
+/// stdout [`Redirect`], an optional stdout append [`RedirectAppend`], an
+/// optional stderr [`StderrRedirect`], and an optional stderr append
+/// [`StderrRedirectAppend`].
 ///
 /// If the line contains `>` or `1>` followed by a filename, that operator and
 /// the filename are stripped from the argument list and returned as a
 /// [`Redirect`].  If the line contains `>>` followed by a filename, it is
 /// returned as a [`RedirectAppend`] (existing content preserved).  If the
 /// line contains `2>` followed by a filename, that operator and the filename
-/// are returned as a [`StderrRedirect`].
+/// are returned as a [`StderrRedirect`].  If the line contains `2>>` followed
+/// by a filename, it is returned as a [`StderrRedirectAppend`].
 ///
 /// Only unquoted redirect operators are recognised; an operator character that
 /// appears inside quotes is treated as a literal argument character.
@@ -30,11 +32,13 @@ pub fn parse(
     Option<Redirect>,
     Option<RedirectAppend>,
     Option<StderrRedirect>,
+    Option<StderrRedirectAppend>,
 ) {
     let (command, raw_args) = split_command_and_args(buffer);
     let command = parse_command(&command);
 
-    let (args, redirect, redirect_append, stderr_redirect) = extract_redirects(raw_args);
+    let (args, redirect, redirect_append, stderr_redirect, stderr_redirect_append) =
+        extract_redirects(raw_args);
 
     let args = args
         .into_iter()
@@ -43,30 +47,39 @@ pub fn parse(
             style => Arg::Quoted { bytes, style },
         })
         .collect();
-    (command, args, redirect, redirect_append, stderr_redirect)
+    (
+        command,
+        args,
+        redirect,
+        redirect_append,
+        stderr_redirect,
+        stderr_redirect_append,
+    )
 }
 
 /// Raw argument token: byte content and its quoting style.
 type RawArg = (Vec<u8>, QuoteStyle);
 
 /// Result of redirect extraction: remaining args, optional stdout redirect,
-/// optional stdout append redirect, and optional stderr redirect.
+/// optional stdout append redirect, optional stderr redirect, and optional
+/// stderr append redirect.
 type ExtractResult = (
     Vec<RawArg>,
     Option<Redirect>,
     Option<RedirectAppend>,
     Option<StderrRedirect>,
+    Option<StderrRedirectAppend>,
 );
 
-/// Scan `raw_args` for unquoted redirect operators (`>`, `1>`, `>>`, `2>`).
+/// Scan `raw_args` for unquoted redirect operators (`>`, `1>`, `>>`, `2>`, `2>>`).
 ///
 /// Returns the remaining argument list (with operators and their target
 /// filenames removed), an optional stdout [`Redirect`], an optional stdout
-/// append [`RedirectAppend`], and an optional stderr [`StderrRedirect`]. If
-/// multiple operators of the same kind appear, only the last one is returned;
-/// earlier ones are stripped from the argument list but do not trigger
-/// intermediate bash-style side effects such as creating or truncating their
-/// targets.
+/// append [`RedirectAppend`], an optional stderr [`StderrRedirect`], and an
+/// optional stderr append [`StderrRedirectAppend`]. If multiple operators of
+/// the same kind appear, only the last one is returned; earlier ones are
+/// stripped from the argument list but do not trigger intermediate bash-style
+/// side effects such as creating or truncating their targets.
 ///
 /// When a redirect operator appears without a following filename token (e.g.
 /// a trailing `>>`), the operator is kept as a normal argument rather than
@@ -84,6 +97,7 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
     let mut redirect: Option<Redirect> = None;
     let mut redirect_append: Option<RedirectAppend> = None;
     let mut stderr_redirect: Option<StderrRedirect> = None;
+    let mut stderr_redirect_append: Option<StderrRedirectAppend> = None;
 
     let mut iter = raw_args.into_iter().peekable();
     while let Some((bytes, style)) = iter.next() {
@@ -118,6 +132,21 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
                 }
                 continue;
             }
+            // Check `2>>` before `2>` so the longer operator wins.
+            if token == b"2>>" {
+                // The next token is the stderr append redirect target.
+                if let Some((target_bytes, _)) = iter.next() {
+                    let target = std::path::PathBuf::from(
+                        String::from_utf8_lossy(&target_bytes).as_ref(),
+                    );
+                    stderr_redirect_append = Some(StderrRedirectAppend::new(target));
+                } else {
+                    // No filename follows the operator — keep it as a literal
+                    // argument rather than silently dropping it.
+                    out_args.push((bytes, style));
+                }
+                continue;
+            }
             if token == b"2>" {
                 // The next token is the stderr redirect target.
                 if let Some((target_bytes, _)) = iter.next() {
@@ -136,7 +165,13 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
         out_args.push((bytes, style));
     }
 
-    (out_args, redirect, redirect_append, stderr_redirect)
+    (
+        out_args,
+        redirect,
+        redirect_append,
+        stderr_redirect,
+        stderr_redirect_append,
+    )
 }
 
 /// Split the trimmed input buffer into a command token and zero or more argument tokens.
@@ -611,7 +646,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello > out.txt");
+        let (_, args, redirect, redirect_append, stderr_redirect, _) = parse(b"echo hello > out.txt");
         assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
@@ -621,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello 1> out.txt");
+        let (_, args, redirect, redirect_append, stderr_redirect, _) = parse(b"echo hello 1> out.txt");
         assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_some(), "redirect should be Some for 1>");
         assert_eq!(redirect.unwrap().target, std::path::PathBuf::from("out.txt"));
@@ -631,7 +666,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_2gt() {
-        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello 2> err.txt");
+        let (_, args, redirect, redirect_append, stderr_redirect, _) = parse(b"echo hello 2> err.txt");
         assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_none(), "stdout redirect should be None for 2>");
         assert!(redirect_append.is_none());
@@ -641,7 +676,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gtgt() {
-        let (_, args, redirect, redirect_append, stderr_redirect) =
+        let (_, args, redirect, redirect_append, stderr_redirect, _) =
             parse(b"echo hello >> out.txt");
         assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
         assert!(redirect.is_none(), "stdout truncate redirect should be None for >>");
@@ -654,9 +689,44 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_redirect_2gtgt() {
+        let (_, args, redirect, redirect_append, stderr_redirect, stderr_redirect_append) =
+            parse(b"exit notanumber 2>> err.txt");
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["notanumber"]
+        );
+        assert!(redirect.is_none());
+        assert!(redirect_append.is_none());
+        assert!(stderr_redirect.is_none());
+        assert!(
+            stderr_redirect_append.is_some(),
+            "2>> should produce StderrRedirectAppend"
+        );
+        assert_eq!(
+            stderr_redirect_append.unwrap().target,
+            std::path::PathBuf::from("err.txt")
+        );
+    }
+
+    #[test]
+    fn test_parse_stderr_append_redirect_trailing_operator_kept_as_arg() {
+        let (_, args, _, _, _, stderr_redirect_append) = parse(b"echo 2>>");
+        assert!(
+            stderr_redirect_append.is_none(),
+            "no redirect target means no StderrRedirectAppend"
+        );
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["2>>"],
+            "trailing `2>>` should be kept as a literal arg"
+        );
+    }
+
+    #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
         // A trailing `>` with no following filename should be preserved as a literal argument.
-        let (_, args, redirect, redirect_append, _) = parse(b"echo >");
+        let (_, args, redirect, redirect_append, _, _) = parse(b"echo >");
         assert!(redirect.is_none(), "no redirect target means no Redirect");
         assert!(redirect_append.is_none());
         assert_eq!(
@@ -669,7 +739,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
         // A trailing `>>` with no following filename should be preserved as a literal argument.
-        let (_, args, redirect, redirect_append, _) = parse(b"echo >>");
+        let (_, args, redirect, redirect_append, _, _) = parse(b"echo >>");
         assert!(redirect.is_none());
         assert!(redirect_append.is_none(), "no redirect target means no RedirectAppend");
         assert_eq!(
@@ -682,7 +752,7 @@ mod tests {
     #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
         // A trailing `2>` with no following filename should be preserved as a literal argument.
-        let (_, args, _, _, stderr_redirect) = parse(b"echo 2>");
+        let (_, args, _, _, stderr_redirect, _) = parse(b"echo 2>");
         assert!(stderr_redirect.is_none(), "no redirect target means no StderrRedirect");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -693,7 +763,7 @@ mod tests {
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, redirect, redirect_append, stderr_redirect) = parse(b"echo hello world");
+        let (_, args, redirect, redirect_append, stderr_redirect, _) = parse(b"echo hello world");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -57,3 +57,25 @@ impl StderrRedirect {
         }
     }
 }
+
+/// Stderr append-redirection target extracted from a command line.
+///
+/// When the parser encounters `2>>` followed by a filename, it records the
+/// target here and removes the operator tokens from the argument list.
+/// Standard output is unaffected.  Unlike [`StderrRedirect`], existing file
+/// content is preserved — new stderr is appended at the end.  If the file
+/// does not exist it is created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StderrRedirectAppend {
+    /// Path to the file that should receive appended standard error.
+    pub target: std::path::PathBuf,
+}
+
+impl StderrRedirectAppend {
+    /// Create a new stderr append redirect targeting `target`.
+    pub fn new(target: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -10,7 +10,7 @@ use crate::{
     exit::ExitCode,
     io::{ShellIo, StandardIo},
     parser,
-    redirect::{Redirect, RedirectAppend, StderrRedirect},
+    redirect::{Redirect, RedirectAppend, StderrRedirect, StderrRedirectAppend},
 };
 
 /// The ferrish shell REPL.
@@ -73,8 +73,16 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect, redirect_append, stderr_redirect) = parser::parse(buffer);
-            match self.execute_command(command.clone(), args, redirect, redirect_append, stderr_redirect) {
+            let (command, args, redirect, redirect_append, stderr_redirect, stderr_redirect_append) =
+                parser::parse(buffer);
+            match self.execute_command(
+                command.clone(),
+                args,
+                redirect,
+                redirect_append,
+                stderr_redirect,
+                stderr_redirect_append,
+            ) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
@@ -101,8 +109,16 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, redirect, redirect_append, stderr_redirect) = parser::parse(buffer);
-            if let Some(exit_code) = self.execute_command(command, args, redirect, redirect_append, stderr_redirect)? {
+            let (command, args, redirect, redirect_append, stderr_redirect, stderr_redirect_append) =
+                parser::parse(buffer);
+            if let Some(exit_code) = self.execute_command(
+                command,
+                args,
+                redirect,
+                redirect_append,
+                stderr_redirect,
+                stderr_redirect_append,
+            )? {
                 return Ok(exit_code);
             }
         }
@@ -118,6 +134,7 @@ impl<IO: ShellIo> Shell<IO> {
         redirect: Option<Redirect>,
         redirect_append: Option<RedirectAppend>,
         stderr_redirect: Option<StderrRedirect>,
+        stderr_redirect_append: Option<StderrRedirectAppend>,
     ) -> ShellResult<Option<ExitCode>> {
         executor::execute(
             command,
@@ -127,6 +144,7 @@ impl<IO: ShellIo> Shell<IO> {
             redirect,
             redirect_append,
             stderr_redirect,
+            stderr_redirect_append,
         )
     }
 }
@@ -226,7 +244,7 @@ mod tests {
             ),
         );
         let args = vec![Arg::from("test"), Arg::from("message")];
-        let result = shell.execute_command(command, args, None, None, None);
+        let result = shell.execute_command(command, args, None, None, None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
         {
@@ -245,7 +263,7 @@ mod tests {
                 crate::command::builtin::BuiltInName::Exit,
             ),
         );
-        let result = shell.execute_command(command, vec![], None, None, None);
+        let result = shell.execute_command(command, vec![], None, None, None, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(ExitCode::SUCCESS));
     }

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -356,3 +356,123 @@ fn test_stderr_redirect_does_not_affect_subsequent_stdout() {
         .expect("err.txt should exist");
     assert!(!contents.is_empty(), "cat's stderr should have been captured to file");
 }
+
+// ============================================================================
+// Stderr append redirection (2>>) integration tests
+// ============================================================================
+
+/// `exit notanumber 2>> err.txt` on a new file should create it with the error.
+#[test]
+fn test_stderr_append_redirect_creates_file_when_absent() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("exit notanumber 2>> err.txt")
+        .run();
+
+    // Error should have gone to the file, not to terminal stderr.
+    assert!(
+        !result.error().contains("numeric argument required"),
+        "redirected stderr must not appear on terminal stderr"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should have been created by 2>>");
+    assert!(
+        contents.contains("numeric argument required"),
+        "expected error message in redirect file, got: {contents}"
+    );
+}
+
+/// A second `2>>` to the same file appends rather than overwrites.
+#[test]
+fn test_stderr_append_redirect_preserves_existing_content() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("err.txt", "existing\n")
+        .script("exit notanumber 2>> err.txt")
+        .run();
+
+    assert!(
+        !result.error().contains("numeric argument required"),
+        "redirected stderr must not appear on terminal stderr"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should still exist");
+    assert!(
+        contents.starts_with("existing\n"),
+        "original content should be preserved: {contents}"
+    );
+    assert!(
+        contents.contains("numeric argument required"),
+        "appended error should appear after existing content: {contents}"
+    );
+}
+
+/// `2>>` should capture only stderr; stdout should still reach the terminal.
+#[test]
+fn test_stderr_append_redirect_stdout_still_goes_to_terminal() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo visible 2>> err.txt")
+        .run();
+
+    assert!(
+        result.output_contains("visible"),
+        "stdout should still go to terminal when only stderr is append-redirected"
+    );
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should have been created by 2>>");
+    assert!(
+        contents.is_empty(),
+        "stderr append file should be empty when no errors occur: {contents}"
+    );
+}
+
+/// A trailing `2>>` without a filename should be kept as a literal argument.
+#[test]
+fn test_stderr_append_redirect_trailing_operator_kept_as_arg() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo 2>>")
+        .run();
+
+    result.assert_output_contains("2>>");
+}
+
+/// Append stderr redirection should work for external executables.
+/// Uses `cat /nonexistent` (writes to stderr) with a pre-existing file to
+/// verify that the threaded pipe-drain path appends stderr correctly.
+/// The shell itself may print a non-zero-exit notice to terminal stderr, but
+/// `cat`'s own error message should go to the redirect file, not the terminal.
+#[cfg(unix)]
+#[test]
+fn test_stderr_append_redirect_external_executable_appends_to_file() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .with_file("err.txt", "existing\n")
+        .script("cat /nonexistent 2>> err.txt")
+        .run();
+
+    let home = result.home_dir().expect("has home dir");
+    let contents = std::fs::read_to_string(home.join("err.txt"))
+        .expect("err.txt should exist after 2>> redirect");
+    assert!(
+        contents.starts_with("existing\n"),
+        "original content should be preserved: {contents}"
+    );
+    // cat's own stderr ("No such file or directory") should have been appended.
+    assert!(
+        contents.len() > "existing\n".len(),
+        "cat's stderr should have been appended after existing content: {contents}"
+    );
+    // cat's error message should NOT appear on the terminal — it went to the file.
+    assert!(
+        !result.error().contains("No such file or directory"),
+        "cat's own error message should not appear on terminal stderr"
+    );
+}

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -470,9 +470,13 @@ fn test_stderr_append_redirect_external_executable_appends_to_file() {
         contents.len() > "existing\n".len(),
         "cat's stderr should have been appended after existing content: {contents}"
     );
-    // cat's error message should NOT appear on the terminal — it went to the file.
     assert!(
-        !result.error().contains("No such file or directory"),
-        "cat's own error message should not appear on terminal stderr"
+        contents.contains("/nonexistent"),
+        "redirected stderr should mention the missing path: {contents}"
+    );
+    // cat's own error output should NOT appear on the terminal — it went to the file.
+    assert!(
+        !result.error().contains("/nonexistent"),
+        "cat's own error output should not appear on terminal stderr"
     );
 }


### PR DESCRIPTION
## Summary

- Adds `StderrRedirectAppend` struct to `src/redirect.rs` (mirrors `RedirectAppend` for stderr)
- Parser recognizes `2>>` token (checked before `2>` so the longer operator wins); trailing `2>>` without a filename is kept as a literal argument
- Executor opens stderr file with `OpenOptions::append(true).create(true)` when `stderr_redirect_append` is present; `2>` still takes precedence if both are present
- `shell.rs` threads `Option<StderrRedirectAppend>` through `parse` → `execute_command` → `executor::execute`
- Adds `#[allow(clippy::too_many_arguments)]` on `execute` with a comment pointing to issue #26 where the parameter list will be consolidated into an `ExecuteOptions` struct
- Integration tests in `tests/redirect.rs` cover: file creation, existing-content preservation, stdout passthrough, trailing-operator kept-as-arg, and external-executable append

Closes #25

Co-Authored-By: Claude <noreply@anthropic.com>