### PR TITLE
feat: integrate miette for structured error output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,7 +79,6 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "ferrish"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "is_executable",
  "miette",
  "soft-canonicalize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,49 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "bitflags"
@@ -48,6 +87,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "is_executable",
+ "miette",
  "soft-canonicalize",
  "strum",
  "tempfile",
@@ -67,10 +107,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_executable"
@@ -94,10 +146,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "proc-canonicalize"
@@ -131,6 +243,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
@@ -177,6 +295,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +337,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -225,6 +384,24 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.92"
 [dependencies]
 anyhow = "1.0"
 is_executable = "1.0"
+miette = { version = "7", features = ["fancy"] }
 soft-canonicalize = { version = "0.5.4", features = ["dunce"] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 rust-version = "1.92"
 
 [dependencies]
-anyhow = "1.0"
 is_executable = "1.0"
 miette = { version = "7", features = ["fancy"] }
 soft-canonicalize = { version = "0.5.4", features = ["dunce"] }

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,7 +4,7 @@ pub(crate) mod builtin;
 pub(crate) mod executable;
 
 /// Represents a shell command.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     /// A shell built-in command (e.g. `echo`, `cd`, `exit`).
     BuiltIn(builtin::BuiltInCommand),

--- a/src/command/executable.rs
+++ b/src/command/executable.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 /// An external executable command located on `PATH`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecutableCommand {
     file_path: PathBuf,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::process::ExitStatus;
 
 use crate::arg::{Arg, QuoteStyle};
+use crate::command::Command;
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
@@ -63,6 +64,22 @@ pub enum ShellError {
     #[diagnostic(code(ferrish::exec::failed))]
     ExecutionFailed(#[source] std::io::Error),
 
+    // --- Command context ---
+    /// Wraps any execution error with the command that caused it.
+    ///
+    /// Applied at the dispatch boundary so individual error variants stay lean.
+    #[error("{command}: {source}")]
+    #[diagnostic(code(ferrish::exec::command_error))]
+    InCommand {
+        /// The command that was executing when the error occurred.
+        command: Command,
+        /// The underlying shell error.
+        #[source]
+        #[diagnostic_source]
+        source: Box<ShellError>,
+    },
+
+
     // --- I/O ---
     /// An I/O error propagated from the underlying stream.
     #[error(transparent)]
@@ -85,24 +102,28 @@ pub enum ShellError {
     },
 }
 
+impl std::borrow::Borrow<dyn miette::Diagnostic> for Box<ShellError> {
+    fn borrow(&self) -> &(dyn miette::Diagnostic + 'static) {
+        self.as_ref()
+    }
+}
+
 impl PartialEq for ShellError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::CommandNotFound { name: l }, Self::CommandNotFound { name: r }) => l == r,
-            (Self::FileNotFound { arg: l_arg }, Self::FileNotFound { arg: r_arg }) => {
-                l_arg == r_arg
-            }
-            (Self::IsADirectory { arg: l_arg }, Self::IsADirectory { arg: r_arg }) => {
-                l_arg == r_arg
-            }
-            (Self::NotADirectory { arg: l_arg }, Self::NotADirectory { arg: r_arg }) => {
-                l_arg == r_arg
-            }
+            (Self::FileNotFound { arg: la }, Self::FileNotFound { arg: ra }) => la == ra,
+            (Self::IsADirectory { arg: la }, Self::IsADirectory { arg: ra }) => la == ra,
+            (Self::NotADirectory { arg: la }, Self::NotADirectory { arg: ra }) => la == ra,
             (Self::NonZeroExit(l0), Self::NonZeroExit(r0)) => l0 == r0,
             (Self::ExecutionFailed(l0), Self::ExecutionFailed(r0)) => {
                 l0.raw_os_error() == r0.raw_os_error()
             }
             (Self::Io(l0), Self::Io(r0)) => l0.raw_os_error() == r0.raw_os_error(),
+            (
+                Self::InCommand { command: lc, source: ls },
+                Self::InCommand { command: rc, source: rs },
+            ) => lc == rc && ls == rs,
             (
                 Self::UnclosedQuote {
                     style: l_style,
@@ -121,7 +142,11 @@ impl PartialEq for ShellError {
 impl ShellError {
     /// Check if this error is fatal (should stop execution)
     pub fn is_fatal(&self) -> bool {
-        matches!(self, ShellError::ExecutionFailed(_))
+        match self {
+            ShellError::ExecutionFailed(_) => true,
+            ShellError::InCommand { source, .. } => source.is_fatal(),
+            _ => false,
+        }
     }
 }
 
@@ -143,26 +168,42 @@ mod tests {
 
     #[test]
     fn test_display_file_not_found() {
-        let err = ShellError::FileNotFound {
-            arg: Arg::from("/path/to/file"),
-        };
+        let err = ShellError::FileNotFound { arg: Arg::from("/path/to/file") };
         assert_eq!(err.to_string(), "no such file or directory: /path/to/file");
     }
 
     #[test]
     fn test_display_is_a_directory() {
-        let err = ShellError::IsADirectory {
-            arg: Arg::from("/some/dir"),
-        };
+        let err = ShellError::IsADirectory { arg: Arg::from("/some/dir") };
         assert_eq!(err.to_string(), "is a directory: /some/dir");
     }
 
     #[test]
     fn test_display_not_a_directory() {
-        let err = ShellError::NotADirectory {
-            arg: Arg::from("/some/file"),
-        };
+        let err = ShellError::NotADirectory { arg: Arg::from("/some/file") };
         assert_eq!(err.to_string(), "not a directory: /some/file");
+    }
+
+    #[test]
+    fn test_in_command_prepends_command_name() {
+        let inner = ShellError::FileNotFound { arg: Arg::from("/no/such") };
+        let err = ShellError::InCommand {
+            command: Command::BuiltIn(crate::command::builtin::BuiltInCommand::new(
+                crate::command::builtin::BuiltInName::Cd,
+            )),
+            source: Box::new(inner),
+        };
+        assert_eq!(err.to_string(), "cd: no such file or directory: /no/such");
+    }
+
+    #[test]
+    fn test_in_command_fatal_delegates_to_source() {
+        let inner = ShellError::ExecutionFailed(std::io::Error::last_os_error());
+        let err = ShellError::InCommand {
+            command: Command::Unrecognized(b"mycmd".to_vec()),
+            source: Box::new(inner),
+        };
+        assert!(err.is_fatal());
     }
 
     #[test]
@@ -197,9 +238,7 @@ mod tests {
 
     #[test]
     fn test_is_fatal_file_not_found() {
-        let err = ShellError::FileNotFound {
-            arg: Arg::from("test"),
-        };
+        let err = ShellError::FileNotFound { arg: Arg::from("test") };
         assert!(!err.is_fatal());
     }
 
@@ -214,23 +253,15 @@ mod tests {
 
     #[test]
     fn test_equality_file_not_found() {
-        let err1 = ShellError::FileNotFound {
-            arg: Arg::from("file1"),
-        };
-        let err2 = ShellError::FileNotFound {
-            arg: Arg::from("file1"),
-        };
+        let err1 = ShellError::FileNotFound { arg: Arg::from("file1") };
+        let err2 = ShellError::FileNotFound { arg: Arg::from("file1") };
         assert_eq!(err1, err2);
     }
 
     #[test]
     fn test_inequality_file_not_found() {
-        let err1 = ShellError::FileNotFound {
-            arg: Arg::from("file1"),
-        };
-        let err2 = ShellError::FileNotFound {
-            arg: Arg::from("file2"),
-        };
+        let err1 = ShellError::FileNotFound { arg: Arg::from("file1") };
+        let err2 = ShellError::FileNotFound { arg: Arg::from("file2") };
         assert_ne!(err1, err2);
     }
 
@@ -246,19 +277,15 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::process::ExitStatusExt;
-            let status1 = ExitStatusExt::from_raw(42 << 8);
-            let status2 = ExitStatusExt::from_raw(42 << 8);
-            let e1 = ShellError::NonZeroExit(status1);
-            let e2 = ShellError::NonZeroExit(status2);
+            let e1 = ShellError::NonZeroExit(ExitStatusExt::from_raw(42 << 8));
+            let e2 = ShellError::NonZeroExit(ExitStatusExt::from_raw(42 << 8));
             assert_eq!(e1, e2);
         }
         #[cfg(windows)]
         {
             use std::os::windows::process::ExitStatusExt;
-            let status1 = ExitStatusExt::from_raw(42);
-            let status2 = ExitStatusExt::from_raw(42);
-            let e1 = ShellError::NonZeroExit(status1);
-            let e2 = ShellError::NonZeroExit(status2);
+            let e1 = ShellError::NonZeroExit(ExitStatusExt::from_raw(42));
+            let e2 = ShellError::NonZeroExit(ExitStatusExt::from_raw(42));
             assert_eq!(e1, e2);
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::process::ExitStatus;
 
-use crate::arg::Arg;
+use crate::arg::{Arg, QuoteStyle};
+use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
 /// Convenience result type for shell execution results
@@ -10,20 +11,23 @@ pub type ShellResult<T> = anyhow::Result<T, ShellError>;
 ///
 /// These are domain errors that the shell can handle gracefully.
 /// They're displayed to the user but don't crash the shell.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Diagnostic)]
 pub enum ShellError {
     // --- Command-level ---
     /// The requested command could not be found as a built-in or on `PATH`.
     #[error("command not found")]
+    #[diagnostic(code(ferrish::command_not_found))]
     CommandNotFound,
 
     /// A required operand was not provided.
     #[error("missing operand")]
+    #[diagnostic(code(ferrish::missing_operand))]
     MissingOperand,
 
     // --- File system ---
     /// The path does not exist on the filesystem.
     #[error("no such file or directory: {arg}")]
+    #[diagnostic(code(ferrish::fs::not_found))]
     FileNotFound {
         /// The argument that referred to the missing path.
         arg: Arg,
@@ -31,6 +35,7 @@ pub enum ShellError {
 
     /// The path exists but is a directory where a regular file was expected.
     #[error("is a directory: {arg}")]
+    #[diagnostic(code(ferrish::fs::is_a_directory))]
     IsADirectory {
         /// The argument that referred to the directory.
         arg: Arg,
@@ -38,6 +43,7 @@ pub enum ShellError {
 
     /// The path exists but is a regular file where a directory was expected.
     #[error("not a directory: {arg}")]
+    #[diagnostic(code(ferrish::fs::not_a_directory))]
     NotADirectory {
         /// The argument that referred to the non-directory path.
         arg: Arg,
@@ -46,16 +52,34 @@ pub enum ShellError {
     // --- Process execution ---
     /// The child process exited with a non-zero status code.
     #[error("exited with status {0}")]
+    #[diagnostic(code(ferrish::exec::non_zero_exit))]
     NonZeroExit(ExitStatus),
 
     /// The shell failed to spawn or wait on the child process.
     #[error("failed to execute: {0}")]
+    #[diagnostic(code(ferrish::exec::failed))]
     ExecutionFailed(#[source] std::io::Error),
 
     // --- I/O ---
     /// An I/O error propagated from the underlying stream.
     #[error(transparent)]
+    #[diagnostic(code(ferrish::io))]
     Io(#[from] std::io::Error),
+
+    // --- Parse ---
+    /// An opening quote was never closed before end of input.
+    #[error("unclosed {style:?} quote")]
+    #[diagnostic(
+        code(ferrish::parse::unclosed_quote),
+        help("add the matching quote to close this token")
+    )]
+    UnclosedQuote {
+        /// The kind of quote that was opened but never closed.
+        style: QuoteStyle,
+        /// Byte offset of the opening quote character in the source line.
+        #[label("quote opened here")]
+        span: SourceSpan,
+    },
 }
 
 impl PartialEq for ShellError {
@@ -75,6 +99,16 @@ impl PartialEq for ShellError {
                 l0.raw_os_error() == r0.raw_os_error()
             }
             (Self::Io(l0), Self::Io(r0)) => l0.raw_os_error() == r0.raw_os_error(),
+            (
+                Self::UnclosedQuote {
+                    style: l_style,
+                    span: l_span,
+                },
+                Self::UnclosedQuote {
+                    style: r_style,
+                    span: r_span,
+                },
+            ) => l_style == r_style && l_span == r_span,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
@@ -128,6 +162,24 @@ mod tests {
     }
 
     #[test]
+    fn test_display_unclosed_quote_single() {
+        let err = ShellError::UnclosedQuote {
+            style: QuoteStyle::Single,
+            span: SourceSpan::from((0, 1)),
+        };
+        assert_eq!(err.to_string(), "unclosed Single quote");
+    }
+
+    #[test]
+    fn test_display_unclosed_quote_double() {
+        let err = ShellError::UnclosedQuote {
+            style: QuoteStyle::Double,
+            span: SourceSpan::from((5, 1)),
+        };
+        assert_eq!(err.to_string(), "unclosed Double quote");
+    }
+
+    #[test]
     fn test_is_fatal_execution_failed() {
         let err = ShellError::ExecutionFailed(std::io::Error::last_os_error());
         assert!(err.is_fatal());
@@ -143,6 +195,15 @@ mod tests {
     fn test_is_fatal_file_not_found() {
         let err = ShellError::FileNotFound {
             arg: Arg::from("test"),
+        };
+        assert!(!err.is_fatal());
+    }
+
+    #[test]
+    fn test_is_fatal_unclosed_quote() {
+        let err = ShellError::UnclosedQuote {
+            style: QuoteStyle::Double,
+            span: SourceSpan::from((0, 1)),
         };
         assert!(!err.is_fatal());
     }
@@ -207,5 +268,31 @@ mod tests {
         let i1 = ShellError::Io(std::io::Error::from_raw_os_error(4));
         let i2 = ShellError::Io(std::io::Error::from_raw_os_error(4));
         assert_eq!(i1, i2);
+    }
+
+    #[test]
+    fn test_equality_unclosed_quote() {
+        let e1 = ShellError::UnclosedQuote {
+            style: QuoteStyle::Single,
+            span: SourceSpan::from((3, 1)),
+        };
+        let e2 = ShellError::UnclosedQuote {
+            style: QuoteStyle::Single,
+            span: SourceSpan::from((3, 1)),
+        };
+        assert_eq!(e1, e2);
+    }
+
+    #[test]
+    fn test_inequality_unclosed_quote_different_style() {
+        let e1 = ShellError::UnclosedQuote {
+            style: QuoteStyle::Single,
+            span: SourceSpan::from((3, 1)),
+        };
+        let e2 = ShellError::UnclosedQuote {
+            style: QuoteStyle::Double,
+            span: SourceSpan::from((3, 1)),
+        };
+        assert_ne!(e1, e2);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
 /// Convenience result type for shell execution results
-pub type ShellResult<T> = anyhow::Result<T, ShellError>;
+pub type ShellResult<T> = Result<T, ShellError>;
 
 /// Errors that can occur during command execution
 ///
@@ -15,9 +15,12 @@ pub type ShellResult<T> = anyhow::Result<T, ShellError>;
 pub enum ShellError {
     // --- Command-level ---
     /// The requested command could not be found as a built-in or on `PATH`.
-    #[error("command not found")]
+    #[error("{name}: command not found")]
     #[diagnostic(code(ferrish::command_not_found))]
-    CommandNotFound,
+    CommandNotFound {
+        /// The command name that was not found.
+        name: String,
+    },
 
     /// A required operand was not provided.
     #[error("missing operand")]
@@ -76,7 +79,7 @@ pub enum ShellError {
     UnclosedQuote {
         /// The kind of quote that was opened but never closed.
         style: QuoteStyle,
-        /// Byte offset of the opening quote character in the source line.
+        /// Byte offset of the opening quote character in the trimmed input line passed to the parser.
         #[label("quote opened here")]
         span: SourceSpan,
     },
@@ -85,6 +88,7 @@ pub enum ShellError {
 impl PartialEq for ShellError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Self::CommandNotFound { name: l }, Self::CommandNotFound { name: r }) => l == r,
             (Self::FileNotFound { arg: l_arg }, Self::FileNotFound { arg: r_arg }) => {
                 l_arg == r_arg
             }
@@ -127,8 +131,8 @@ mod tests {
 
     #[test]
     fn test_display_command_not_found() {
-        let err = ShellError::CommandNotFound;
-        assert_eq!(err.to_string(), "command not found");
+        let err = ShellError::CommandNotFound { name: "foo".to_string() };
+        assert_eq!(err.to_string(), "foo: command not found");
     }
 
     #[test]
@@ -187,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_is_fatal_command_not_found() {
-        let err = ShellError::CommandNotFound;
+        let err = ShellError::CommandNotFound { name: "foo".to_string() };
         assert!(!err.is_fatal());
     }
 
@@ -232,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_equality_different_variant() {
-        let err1 = ShellError::CommandNotFound;
+        let err1 = ShellError::CommandNotFound { name: "foo".to_string() };
         let err2 = ShellError::MissingOperand;
         assert_ne!(err1, err2);
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -131,8 +131,8 @@ fn execute_with_writers(
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     let result = match &command {
-        Command::BuiltIn(builtin) => execute_builtin(builtin.clone(), args, out, err, ctx),
-        Command::Executable(executable) => execute_executable(executable.clone(), args, out, err, ctx),
+        Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
+        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx),
         Command::Unrecognized(cmd) => {
             return Err(ShellError::CommandNotFound {
                 name: String::from_utf8_lossy(cmd).into_owned(),
@@ -143,7 +143,7 @@ fn execute_with_writers(
 }
 
 fn execute_builtin(
-    builtin: BuiltInCommand,
+    builtin: &BuiltInCommand,
     args: Args,
     out: &mut dyn std::io::Write,
     err: &mut dyn std::io::Write,
@@ -239,7 +239,7 @@ fn execute_pwd(
 }
 
 fn execute_executable(
-    executable: ExecutableCommand,
+    executable: &ExecutableCommand,
     args: Args,
     out: &mut dyn std::io::Write,
     err: &mut dyn std::io::Write,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -7,6 +7,7 @@ use crate::{
     Arg, Command,
     arg::Args,
     command::builtin::{BuiltInCommand, BuiltInName},
+    command::executable::ExecutableCommand,
     ctx::ShellCtx,
     env::get_path_dirs,
     error::{ShellError, ShellResult},
@@ -129,13 +130,16 @@ fn execute_with_writers(
     err: &mut dyn std::io::Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
-    match command {
-        Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
-        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx),
-        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
-            name: String::from_utf8_lossy(&cmd).into_owned(),
-        }),
-    }
+    let result = match &command {
+        Command::BuiltIn(builtin) => execute_builtin(builtin.clone(), args, out, err, ctx),
+        Command::Executable(executable) => execute_executable(executable.clone(), args, out, err, ctx),
+        Command::Unrecognized(cmd) => {
+            return Err(ShellError::CommandNotFound {
+                name: String::from_utf8_lossy(cmd).into_owned(),
+            })
+        }
+    };
+    result.map_err(|e| ShellError::InCommand { command, source: Box::new(e) })
 }
 
 fn execute_builtin(
@@ -177,13 +181,9 @@ fn execute_cd(args: Args, ctx: &mut ShellCtx) -> ShellResult<()> {
     let new_dir = fs::resolve_path(&target.into(), ctx.home_dir.as_deref(), &ctx.cwd)?;
 
     if !new_dir.exists() {
-        return Err(ShellError::FileNotFound {
-            arg: target.clone(),
-        });
+        return Err(ShellError::FileNotFound { arg: target.clone() });
     } else if !new_dir.is_dir() {
-        return Err(ShellError::NotADirectory {
-            arg: target.clone(),
-        });
+        return Err(ShellError::NotADirectory { arg: target.clone() });
     }
 
     ctx.cwd = new_dir;
@@ -239,7 +239,7 @@ fn execute_pwd(
 }
 
 fn execute_executable(
-    executable: crate::command::executable::ExecutableCommand,
+    executable: ExecutableCommand,
     args: Args,
     out: &mut dyn std::io::Write,
     err: &mut dyn std::io::Write,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -132,7 +132,9 @@ fn execute_with_writers(
     match command {
         Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
         Command::Executable(executable) => execute_executable(executable, args, out, err, ctx),
-        Command::Unrecognized(_) => Err(ShellError::CommandNotFound),
+        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(&cmd).into_owned(),
+        }),
     }
 }
 
@@ -221,7 +223,7 @@ fn execute_type(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
                 .unwrap_or("");
             writeln!(out, "{} is {}", display_name, path.display())?
         }
-        CommandKind::NotFound => return Err(ShellError::CommandNotFound),
+        CommandKind::NotFound => return Err(ShellError::CommandNotFound { name: arg.to_string() }),
     }
 
     Ok(())
@@ -375,7 +377,10 @@ mod tests {
         let mut out: Vec<u8> = Vec::new();
         let result = execute_type(args, &mut out);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap(), ShellError::CommandNotFound);
+        assert_eq!(
+            result.err().unwrap(),
+            ShellError::CommandNotFound { name: "nonexistentcommand".to_string() }
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@ pub use shell::Shell;
 /// let io = MockIo::from_lines(&["echo test", "exit"]);
 /// let mut shell = Shell::builder().with_io(io);
 /// let exit_code = shell.run()?;
-/// # Ok::<(), anyhow::Error>(())
+/// # Ok::<(), miette::Report>(())
 /// ```
-pub fn run() -> anyhow::Result<exit::ExitCode> {
+pub fn run() -> miette::Result<exit::ExitCode> {
     Shell::<crate::io::StandardIo>::builder().with_std_io().run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-fn main() -> anyhow::Result<std::process::ExitCode> {
+fn main() -> miette::Result<std::process::ExitCode> {
     let code = ferrish::run()?;
     Ok(code.into())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,14 @@
 use std::str::FromStr;
 
 use is_executable::IsExecutable;
+use miette::SourceSpan;
 
 use crate::arg::{Arg, Args, QuoteStyle};
 use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
+use crate::error::ShellError;
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 
 /// Parse a raw input line into a [`Command`], its argument list, an optional
@@ -26,13 +28,16 @@ use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 /// appears inside quotes is treated as a literal argument character.
 pub fn parse(
     buffer: &[u8],
-) -> (
-    Command,
-    Args,
-    Option<StdoutRedirection>,
-    Option<StderrRedirection>,
-) {
-    let (command, raw_args) = split_command_and_args(buffer);
+) -> Result<
+    (
+        Command,
+        Args,
+        Option<StdoutRedirection>,
+        Option<StderrRedirection>,
+    ),
+    ShellError,
+> {
+    let (command, raw_args) = split_command_and_args(buffer)?;
     let command = parse_command(&command);
 
     let (args, stdout_redirect, stderr_redirect) = extract_redirects(raw_args);
@@ -44,7 +49,7 @@ pub fn parse(
             style => Arg::Quoted { bytes, style },
         })
         .collect();
-    (command, args, stdout_redirect, stderr_redirect)
+    Ok((command, args, stdout_redirect, stderr_redirect))
 }
 
 /// Raw argument token: byte content and its quoting style.
@@ -134,22 +139,19 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
 /// consumes the backslash (e.g. `\ ` → space, `\\` → `\`).
 ///
 /// Adjacent quoted and unquoted segments are concatenated into a single token.
-fn split_command_and_args(buffer: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>) {
+///
+/// Returns `Err(ShellError::UnclosedQuote)` if a quote is opened but never closed.
+fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), ShellError> {
     let buffer = buffer.trim_ascii();
     let mut parts: Vec<(Vec<u8>, QuoteStyle)> = Vec::new();
 
     let mut current: Vec<u8> = Vec::new();
     let mut in_single_quote = false;
     let mut in_double_quote = false;
-    // Track whether we've started building a token (needed to emit empty tokens
-    // only when inside a quoted empty string at the word boundary — but for
-    // single-quotes the shell spec says empty quotes produce an empty argument
-    // only if they stand alone, which the concatenation logic handles naturally).
     let mut token_started = false;
-    // Quote style for the token currently being built. None = unstarted; once set
-    // to Single or Double it stays unless a byte from a different quoting context
-    // arrives, at which point it becomes Mixed.
     let mut token_style: Option<QuoteStyle> = None;
+    // Byte offset of the opening quote character (relative to the trimmed buffer).
+    let mut quote_open_pos: usize = 0;
 
     let mut i = 0;
     while i < buffer.len() {
@@ -157,14 +159,12 @@ fn split_command_and_args(buffer: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>
 
         if in_single_quote {
             if byte == b'\'' {
-                // Closing quote — exit single-quote mode but stay in current token.
                 in_single_quote = false;
             } else {
                 current.push(byte);
             }
         } else if in_double_quote {
             if byte == b'"' {
-                // Closing double quote — exit double-quote mode but stay in current token.
                 in_double_quote = false;
             } else if byte == b'\\' && i + 1 < buffer.len() {
                 // Inside double quotes, backslash only escapes `"` and `\`.
@@ -187,30 +187,23 @@ fn split_command_and_args(buffer: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>
                 current.push(buffer[i]);
             }
             token_started = true;
-            // A backslash outside quotes is an unquoted context; if quoted bytes
-            // preceded it the token becomes Mixed.
             token_style = match token_style {
                 None | Some(QuoteStyle::None) => Some(QuoteStyle::None),
                 _ => Some(QuoteStyle::Mixed),
             };
         } else if byte == b'\'' {
-            // Opening single quote — enter single-quote mode and mark token as started.
-            // Even empty quotes (e.g. `''`) count as beginning a token so that a
-            // standalone `''` produces one empty argument rather than being dropped.
             in_single_quote = true;
+            quote_open_pos = i;
             token_started = true;
-            // Only keep Single style if the token has been purely single-quoted so far.
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Single);
             } else if !matches!(token_style, Some(QuoteStyle::Single)) {
                 token_style = Some(QuoteStyle::Mixed);
             }
         } else if byte == b'"' {
-            // Opening double quote — enter double-quote mode and mark token as started.
-            // Same empty-quote semantics as single quotes.
             in_double_quote = true;
+            quote_open_pos = i;
             token_started = true;
-            // Only keep Double style if the token has been purely double-quoted so far.
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Double);
             } else if !matches!(token_style, Some(QuoteStyle::Double)) {
@@ -225,7 +218,6 @@ fn split_command_and_args(buffer: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>
         } else {
             current.push(byte);
             token_started = true;
-            // An unquoted byte after a quoted segment makes the token Mixed.
             token_style = match token_style {
                 None | Some(QuoteStyle::None) => Some(QuoteStyle::None),
                 _ => Some(QuoteStyle::Mixed),
@@ -235,24 +227,33 @@ fn split_command_and_args(buffer: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>
         i += 1;
     }
 
-    // Push the last token (may be empty if input was all whitespace after trim,
-    // but trim_ascii above ensures the buffer is non-empty when we reach here).
+    if in_single_quote {
+        return Err(ShellError::UnclosedQuote {
+            style: QuoteStyle::Single,
+            span: SourceSpan::from((quote_open_pos, 1)),
+        });
+    }
+    if in_double_quote {
+        return Err(ShellError::UnclosedQuote {
+            style: QuoteStyle::Double,
+            span: SourceSpan::from((quote_open_pos, 1)),
+        });
+    }
+
     if token_started || !current.is_empty() {
         let style = token_style.unwrap_or(QuoteStyle::None);
         parts.push((current, style));
     }
 
-    // Split into command and args. If parts is empty (blank input after trim),
-    // return an empty command and no args.
     if parts.is_empty() {
-        return (Vec::new(), Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     }
 
     let mut iter = parts.into_iter();
     let (command, _) = iter.next().unwrap_or((Vec::new(), QuoteStyle::None));
     let args: Vec<(Vec<u8>, QuoteStyle)> = iter.collect();
 
-    (command, args)
+    Ok((command, args))
 }
 
 /// Resolve a raw command token to a [`Command`] variant.
@@ -290,14 +291,14 @@ mod tests {
 
     // Helper: split and return command + arg bytes (quoting metadata stripped).
     fn split(input: &[u8]) -> (Vec<u8>, Vec<Vec<u8>>) {
-        let (cmd, args) = split_command_and_args(input);
+        let (cmd, args) = split_command_and_args(input).unwrap();
         let arg_bytes = args.into_iter().map(|(b, _)| b).collect();
         (cmd, arg_bytes)
     }
 
     // Helper: split and return command + (bytes, style) pairs.
     fn split_styled(input: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>) {
-        split_command_and_args(input)
+        split_command_and_args(input).unwrap()
     }
 
     #[test]
@@ -381,7 +382,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_preserves_spaces() {
-        // echo "hello    world" → one arg: "hello    world"
         let (command, args) = split(b"echo \"hello    world\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"hello    world".to_vec()]);
@@ -389,7 +389,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_adjacent_concatenation() {
-        // echo "hello""world" → one arg: "helloworld"
         let (command, args) = split(b"echo \"hello\"\"world\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"helloworld".to_vec()]);
@@ -397,7 +396,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_mixed_adjacent_concatenation() {
-        // echo hello"world" → one arg: "helloworld"
         let (command, args) = split(b"echo hello\"world\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"helloworld".to_vec()]);
@@ -405,7 +403,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_empty_quotes() {
-        // echo "" → one empty arg
         let (command, args) = split(b"echo \"\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"".to_vec()]);
@@ -413,7 +410,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_multiple_args() {
-        // echo "foo bar" "baz qux" → two args: "foo bar", "baz qux"
         let (command, args) = split(b"echo \"foo bar\" \"baz qux\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"foo bar".to_vec(), b"baz qux".to_vec()]);
@@ -421,7 +417,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_with_single_quote_inside() {
-        // Single quotes inside double quotes are literal.
         let (command, args) = split(b"echo \"it's\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"it's".to_vec()]);
@@ -429,7 +424,6 @@ mod tests {
 
     #[test]
     fn test_double_quote_unquoted_mixed() {
-        // echo pre"mid"post → one arg: "premidpost"
         let (command, args) = split(b"echo pre\"mid\"post");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"premidpost".to_vec()]);
@@ -439,7 +433,6 @@ mod tests {
 
     #[test]
     fn test_dquote_backslash_escapes_backslash() {
-        // echo "A \\ escapes itself" → A \ escapes itself
         let (command, args) = split(b"echo \"A \\\\ escapes itself\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"A \\ escapes itself".to_vec()]);
@@ -447,7 +440,6 @@ mod tests {
 
     #[test]
     fn test_dquote_backslash_escapes_dquote() {
-        // echo "A \" inside double quotes" → A " inside double quotes
         let (command, args) = split(b"echo \"A \\\" inside double quotes\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"A \" inside double quotes".to_vec()]);
@@ -455,7 +447,6 @@ mod tests {
 
     #[test]
     fn test_dquote_backslash_non_special_preserved() {
-        // echo "\n" → \n (backslash preserved before non-special char)
         let (command, args) = split(b"echo \"\\n\"");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"\\n".to_vec()]);
@@ -465,7 +456,6 @@ mod tests {
 
     #[test]
     fn test_single_quote_preserves_spaces() {
-        // echo 'hello    world' → one arg: "hello    world"
         let (command, args) = split(b"echo 'hello    world'");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"hello    world".to_vec()]);
@@ -473,7 +463,6 @@ mod tests {
 
     #[test]
     fn test_single_quote_adjacent_concatenation() {
-        // echo 'hello''world' → one arg: "helloworld"
         let (command, args) = split(b"echo 'hello''world'");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"helloworld".to_vec()]);
@@ -481,7 +470,6 @@ mod tests {
 
     #[test]
     fn test_single_quote_mixed_adjacent_concatenation() {
-        // echo hello''world → one arg: "helloworld"
         let (command, args) = split(b"echo hello''world");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"helloworld".to_vec()]);
@@ -489,7 +477,6 @@ mod tests {
 
     #[test]
     fn test_single_quote_backslash_literal() {
-        // Inside single quotes, backslash is literal.
         let (command, args) = split(b"echo 'back\\slash'");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"back\\slash".to_vec()]);
@@ -497,7 +484,6 @@ mod tests {
 
     #[test]
     fn test_single_quote_empty_quotes() {
-        // echo hello''world → "helloworld" (empty quotes ignored mid-token)
         let (command, args) = split(b"echo hello''world");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"helloworld".to_vec()]);
@@ -507,7 +493,6 @@ mod tests {
 
     #[test]
     fn test_backslash_space_literal() {
-        // echo three\ \ \ spaces → one arg: "three   spaces"
         let (command, args) = split(b"echo three\\ \\ \\ spaces");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"three   spaces".to_vec()]);
@@ -515,7 +500,6 @@ mod tests {
 
     #[test]
     fn test_backslash_backslash() {
-        // echo hello\\world → one arg: "hello\world"
         let (command, args) = split(b"echo hello\\\\world");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"hello\\world".to_vec()]);
@@ -523,7 +507,6 @@ mod tests {
 
     #[test]
     fn test_backslash_letter() {
-        // echo test\\nexample → one arg: "testnexample"  (backslash is consumed)
         let (command, args) = split(b"echo test\\nexample");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"testnexample".to_vec()]);
@@ -531,7 +514,6 @@ mod tests {
 
     #[test]
     fn test_backslash_single_quote() {
-        // echo \'hello\' → one arg: "'hello'"  (quotes are made literal)
         let (command, args) = split(b"echo \\'hello\\'");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"'hello'".to_vec()]);
@@ -539,8 +521,6 @@ mod tests {
 
     #[test]
     fn test_backslash_inside_single_quote_is_literal() {
-        // Inside single quotes, backslash is not special.
-        // echo 'back\slash' → one arg: "back\slash"
         let (command, args) = split(b"echo 'back\\slash'");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"back\\slash".to_vec()]);
@@ -548,7 +528,6 @@ mod tests {
 
     #[test]
     fn test_trailing_backslash_consumed_silently() {
-        // A trailing backslash with no following character is silently consumed.
         let (command, args) = split(b"echo hello\\");
         assert_eq!(command, b"echo");
         assert_eq!(args, vec![b"hello".to_vec()]);
@@ -576,38 +555,101 @@ mod tests {
 
     #[test]
     fn test_style_adjacent_single_quoted_stays_single() {
-        // 'hello''world' is purely single-quoted
         let (_, args) = split_styled(b"echo 'hello''world'");
         assert_eq!(args, vec![(b"helloworld".to_vec(), QuoteStyle::Single)]);
     }
 
     #[test]
     fn test_style_mixed_is_mixed() {
-        // pre"mid"post has unquoted bytes → QuoteStyle::Mixed
         let (_, args) = split_styled(b"echo pre\"mid\"post");
         assert_eq!(args, vec![(b"premidpost".to_vec(), QuoteStyle::Mixed)]);
     }
 
     #[test]
     fn test_style_single_then_double_is_mixed() {
-        // 'a'"b" mixes single and double → QuoteStyle::Mixed
         let (_, args) = split_styled(b"echo 'a'\"b\"");
         assert_eq!(args, vec![(b"ab".to_vec(), QuoteStyle::Mixed)]);
     }
 
     #[test]
     fn test_style_unquoted_then_single_is_mixed() {
-        // 1'>' has unquoted '1' then single-quoted '>' → QuoteStyle::Mixed
         let (_, args) = split_styled(b"echo 1'>'");
         assert_eq!(args, vec![(b"1>".to_vec(), QuoteStyle::Mixed)]);
+    }
+
+    // --- Unclosed quote error tests ---
+
+    #[test]
+    fn test_unclosed_double_quote_returns_error() {
+        let result = split_command_and_args(b"echo \"hello");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ShellError::UnclosedQuote {
+                    style: QuoteStyle::Double,
+                    ..
+                }
+            ),
+            "expected UnclosedQuote(Double), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_unclosed_double_quote_span_offset() {
+        let result = split_command_and_args(b"echo \"hello");
+        let err = result.unwrap_err();
+        if let ShellError::UnclosedQuote { span, .. } = err {
+            assert_eq!(span.offset(), 5, "quote opens at byte 5 in 'echo \"hello'");
+        } else {
+            panic!("expected UnclosedQuote");
+        }
+    }
+
+    #[test]
+    fn test_unclosed_single_quote_returns_error() {
+        let result = split_command_and_args(b"echo 'hello");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ShellError::UnclosedQuote {
+                    style: QuoteStyle::Single,
+                    ..
+                }
+            ),
+            "expected UnclosedQuote(Single), got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_unclosed_single_quote_span_offset() {
+        let result = split_command_and_args(b"echo 'hello");
+        let err = result.unwrap_err();
+        if let ShellError::UnclosedQuote { span, .. } = err {
+            assert_eq!(span.offset(), 5, "quote opens at byte 5 in \"echo 'hello\"");
+        } else {
+            panic!("expected UnclosedQuote");
+        }
+    }
+
+    #[test]
+    fn test_unclosed_quote_is_non_fatal() {
+        let result = split_command_and_args(b"echo \"unterminated");
+        let err = result.unwrap_err();
+        assert!(!err.is_fatal());
     }
 
     // --- Redirect extraction tests ---
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello > out.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello > out.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello"]
+        );
         let r = stdout_redirect.expect("stdout redirect should be Some for >");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
@@ -616,8 +658,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello 1> out.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello 1> out.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello"]
+        );
         let r = stdout_redirect.expect("stdout redirect should be Some for 1>");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
@@ -626,8 +672,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello >> out.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello >> out.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello"]
+        );
         let r = stdout_redirect.expect("stdout redirect should be Some for >>");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
@@ -636,8 +686,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_1gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello 1>> out.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello 1>> out.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello"]
+        );
         let r = stdout_redirect.expect("stdout redirect should be Some for 1>>");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
@@ -646,8 +700,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_2gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello 2> err.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hello"]);
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello 2> err.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hello"]
+        );
         assert!(stdout_redirect.is_none(), "stdout redirect should be None for 2>");
         let r = stderr_redirect.expect("stderr redirect should be Some for 2>");
         assert_eq!(r.mode, RedirectMode::Overwrite);
@@ -656,7 +714,8 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_2gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"exit notanumber 2>> err.txt");
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"exit notanumber 2>> err.txt").unwrap();
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["notanumber"]
@@ -669,9 +728,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_last_wins_stdout() {
-        // When `>` and `>>` both appear for stdout, the last operator wins.
-        let (_, args, stdout_redirect, _) = parse(b"echo hi > first.txt >> last.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hi"]);
+        let (_, args, stdout_redirect, _) =
+            parse(b"echo hi > first.txt >> last.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hi"]
+        );
         let r = stdout_redirect.expect("stdout redirect should be Some");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("last.txt"));
@@ -679,9 +741,12 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_last_wins_stderr() {
-        // When `2>` and `2>>` both appear for stderr, the last operator wins.
-        let (_, args, _, stderr_redirect) = parse(b"echo hi 2> first.txt 2>> last.txt");
-        assert_eq!(args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(), vec!["hi"]);
+        let (_, args, _, stderr_redirect) =
+            parse(b"echo hi 2> first.txt 2>> last.txt").unwrap();
+        assert_eq!(
+            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
+            vec!["hi"]
+        );
         let r = stderr_redirect.expect("stderr redirect should be Some");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("last.txt"));
@@ -689,8 +754,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
-        // A trailing `>` with no following filename should be preserved as a literal argument.
-        let (_, args, stdout_redirect, _) = parse(b"echo >");
+        let (_, args, stdout_redirect, _) = parse(b"echo >").unwrap();
         assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -701,8 +765,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
-        // A trailing `>>` with no following filename should be preserved as a literal argument.
-        let (_, args, stdout_redirect, _) = parse(b"echo >>");
+        let (_, args, stdout_redirect, _) = parse(b"echo >>").unwrap();
         assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -713,8 +776,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
-        // A trailing `2>` with no following filename should be preserved as a literal argument.
-        let (_, args, _, stderr_redirect) = parse(b"echo 2>");
+        let (_, args, _, stderr_redirect) = parse(b"echo 2>").unwrap();
         assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -725,9 +787,11 @@ mod tests {
 
     #[test]
     fn test_parse_mixed_quoted_operator_not_a_redirect() {
-        // 1'>' has bytes `1>` but QuoteStyle::Mixed — must not be treated as a redirect.
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo 1'>'");
-        assert!(stdout_redirect.is_none(), "mixed-quoted 1'>' must not trigger a redirect");
+        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo 1'>'").unwrap();
+        assert!(
+            stdout_redirect.is_none(),
+            "mixed-quoted 1'>' must not trigger a redirect"
+        );
         assert!(stderr_redirect.is_none());
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -737,7 +801,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_append_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, _, stderr_redirect) = parse(b"echo 2>>");
+        let (_, args, _, stderr_redirect) = parse(b"echo 2>>").unwrap();
         assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -748,7 +812,8 @@ mod tests {
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo hello world");
+        let (_, args, stdout_redirect, stderr_redirect) =
+            parse(b"echo hello world").unwrap();
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -73,7 +73,16 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer);
+            let src = String::from_utf8_lossy(buffer).into_owned();
+            let (command, args, stdout_redirect, stderr_redirect) =
+                match parser::parse(buffer) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let report = miette::Report::new(e).with_source_code(src);
+                        writeln!(self.io.borrow_mut().err_writer(), "{report:?}")?;
+                        continue;
+                    }
+                };
             match self.execute_command(
                 command.clone(),
                 args,
@@ -84,11 +93,10 @@ impl<IO: ShellIo> Shell<IO> {
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
-                    let e = anyhow::Error::new(e).context(command);
-                    writeln!(self.io.borrow_mut().err_writer(), "{:#}", e)?;
-
+                    let report = miette::Report::new(e).with_source_code(src);
+                    writeln!(self.io.borrow_mut().err_writer(), "{report:?}")?;
                     if fatal {
-                        return Err(e);
+                        return Err(anyhow::anyhow!("fatal shell error"));
                     }
                 }
             }
@@ -106,7 +114,7 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer);
+            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer)?;
             if let Some(exit_code) =
                 self.execute_command(command, args, stdout_redirect, stderr_redirect)?
             {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
 
+use miette::IntoDiagnostic as _;
+
 use crate::{
     Command,
     arg::Args,
@@ -53,17 +55,17 @@ impl<IO: ShellIo> Shell<IO> {
     }
 
     /// Run the interactive REPL loop until `exit` is called or stdin is exhausted.
-    pub fn run(&mut self) -> anyhow::Result<ExitCode> {
+    pub fn run(&mut self) -> miette::Result<ExitCode> {
         loop {
             {
                 let mut io = self.io.borrow_mut();
                 let w = io.out_writer();
-                w.write_all(self.ctx.config.prompt.as_bytes())?;
-                w.flush()?;
+                w.write_all(self.ctx.config.prompt.as_bytes()).into_diagnostic()?;
+                w.flush().into_diagnostic()?;
             }
 
             let mut buffer = Vec::<u8>::new();
-            let bytes = self.io.borrow_mut().read_line(&mut buffer)?;
+            let bytes = self.io.borrow_mut().read_line(&mut buffer).into_diagnostic()?;
             if bytes == 0 {
                 return Ok(ExitCode::SUCCESS);
             }
@@ -79,7 +81,7 @@ impl<IO: ShellIo> Shell<IO> {
                     Ok(r) => r,
                     Err(e) => {
                         let report = miette::Report::new(e).with_source_code(src);
-                        writeln!(self.io.borrow_mut().err_writer(), "{report:?}")?;
+                        writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
                         continue;
                     }
                 };
@@ -94,9 +96,9 @@ impl<IO: ShellIo> Shell<IO> {
                 Err(e) => {
                     let fatal = e.is_fatal();
                     let report = miette::Report::new(e).with_source_code(src);
-                    writeln!(self.io.borrow_mut().err_writer(), "{report:?}")?;
+                    writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
                     if fatal {
-                        return Err(anyhow::anyhow!("fatal shell error"));
+                        return Ok(ExitCode::FAILURE);
                     }
                 }
             }
@@ -104,7 +106,7 @@ impl<IO: ShellIo> Shell<IO> {
     }
 
     /// Execute a sequence of command lines as a non-interactive script.
-    pub fn run_script(&mut self, script: &[&str]) -> anyhow::Result<ExitCode> {
+    pub fn run_script(&mut self, script: &[&str]) -> miette::Result<ExitCode> {
         for line in script {
             let buffer = line.as_bytes();
             let buffer = buffer.trim_ascii();
@@ -114,7 +116,9 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer)?;
+            let src = String::from_utf8_lossy(buffer).into_owned();
+            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer)
+                .map_err(|e| miette::Report::new(e).with_source_code(src))?;
             if let Some(exit_code) =
                 self.execute_command(command, args, stdout_redirect, stderr_redirect)?
             {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -86,7 +86,7 @@ impl<IO: ShellIo> Shell<IO> {
                     }
                 };
             match self.execute_command(
-                command.clone(),
+                command,
                 args,
                 stdout_redirect,
                 stderr_redirect,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -75,12 +75,12 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let src = String::from_utf8_lossy(buffer).into_owned();
+            let make_src = || String::from_utf8_lossy(buffer).into_owned();
             let (command, args, stdout_redirect, stderr_redirect) =
                 match parser::parse(buffer) {
                     Ok(r) => r,
                     Err(e) => {
-                        let report = miette::Report::new(e).with_source_code(src);
+                        let report = miette::Report::new(e).with_source_code(make_src());
                         writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
                         continue;
                     }
@@ -95,7 +95,7 @@ impl<IO: ShellIo> Shell<IO> {
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
-                    let report = miette::Report::new(e).with_source_code(src);
+                    let report = miette::Report::new(e).with_source_code(make_src());
                     writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
                     if fatal {
                         return Ok(ExitCode::FAILURE);
@@ -116,9 +116,11 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let src = String::from_utf8_lossy(buffer).into_owned();
             let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer)
-                .map_err(|e| miette::Report::new(e).with_source_code(src))?;
+                .map_err(|e| {
+                    miette::Report::new(e)
+                        .with_source_code(String::from_utf8_lossy(buffer).into_owned())
+                })?;
             if let Some(exit_code) =
                 self.execute_command(command, args, stdout_redirect, stderr_redirect)?
             {

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -96,6 +96,40 @@ fn test_nonfatal_error_then_continue() {
     result.assert_output_contains("survived");
 }
 
+// ============================================================================
+// Unclosed quote error tests (issue #46)
+// ============================================================================
+
+#[test]
+fn test_unclosed_double_quote_reports_error_and_continues() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo \"hello\necho survived")
+        .run();
+
+    let err = result.error();
+    assert!(
+        err.contains("unclosed") && err.contains("quote"),
+        "expected unclosed quote error, got: {err}"
+    );
+    result.assert_output_contains("survived");
+}
+
+#[test]
+fn test_unclosed_single_quote_reports_error_and_continues() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo 'hello\necho survived")
+        .run();
+
+    let err = result.error();
+    assert!(
+        err.contains("unclosed") && err.contains("quote"),
+        "expected unclosed quote error, got: {err}"
+    );
+    result.assert_output_contains("survived");
+}
+
 /// Unknown command error is written to stderr, not stdout
 #[test]
 fn test_error_goes_to_stderr_not_stdout() {


### PR DESCRIPTION
Adds `miette` (with the `fancy` feature) and wires it into the shell's error rendering path.

All `ShellError` variants now derive `miette::Diagnostic` with error codes (`ferrish::fs::not_found`, `ferrish::exec::non_zero_exit`, etc.), so every runtime failure renders through miette's graphical handler with colorized output. A new `UnclosedQuote` parse error catches the previously-silent case of an unterminated single or double quote, surfacing a span label pointing at the opening quote character. The `parse` function becomes fallible (`Result`), and `Shell::run` handles parse errors inline so the REPL continues after a bad line. `run_script` propagates parse errors via `?`.

Closes #46