### PR TITLE
feat: implement basic two-command pipelines (|)

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -138,19 +138,17 @@ pub fn execute_pipeline(
     io: &mut impl ShellIo,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
-    let mut stages = pipeline;
-
     // Fast path: no pipe operators.
-    if stages.len() == 1 {
-        let (cmd, args, stdout_redir, stderr_redir) = stages.remove(0);
+    if pipeline.len() == 1 {
+        let (cmd, args, stdout_redir, stderr_redir) = pipeline.into_iter().next().unwrap();
         return execute(cmd, args, io, ctx, stdout_redir, stderr_redir);
     }
 
     // Multi-stage: carry the previous stage's captured stdout forward.
     let mut stdin_buf: Option<Vec<u8>> = None;
-    let last_idx = stages.len() - 1;
+    let last_idx = pipeline.len() - 1;
 
-    for (i, (command, args, stdout_redirect, stderr_redirect)) in stages.into_iter().enumerate() {
+    for (i, (command, args, stdout_redirect, stderr_redirect)) in pipeline.into_iter().enumerate() {
         let is_last = i == last_idx;
 
         if is_last {
@@ -265,7 +263,7 @@ fn execute_stage_inner(
             execute_builtin(builtin, args, out, err, ctx)
         }
         Command::Executable(executable) => {
-            execute_executable_with_stdin(executable, args, out, err, ctx, stdin_data)
+            execute_executable(executable, args, out, err, ctx, stdin_data)
         }
         Command::Unrecognized(cmd) => {
             return Err(ShellError::CommandNotFound {
@@ -274,117 +272,6 @@ fn execute_stage_inner(
         }
     };
     result.map_err(|e| ShellError::InCommand { command, source: Box::new(e) })
-}
-
-/// Spawn an external command, optionally feeding `stdin_data` into its stdin,
-/// and capturing its stdout/stderr into the provided writers.
-fn execute_executable_with_stdin(
-    executable: &ExecutableCommand,
-    args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
-    ctx: &ShellCtx,
-    stdin_data: Option<&[u8]>,
-) -> ShellResult<Option<ExitCode>> {
-    use std::io::Write as _;
-    use std::process::Stdio;
-    use std::thread;
-
-    let args = args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
-    let mut child = std::process::Command::new(executable.file_path())
-        .args(args)
-        .current_dir(&ctx.cwd)
-        .stdin(if stdin_data.is_some() { Stdio::piped() } else { Stdio::inherit() })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(ShellError::ExecutionFailed)?;
-
-    // Feed stdin data if present; do this before draining stdout/stderr to
-    // avoid a potential deadlock where the child blocks on stdout while we
-    // block writing stdin.
-    if let (Some(data), Some(mut child_stdin)) = (stdin_data, child.stdin.take()) {
-        let data = data.to_vec();
-        let stdin_thread = thread::spawn(move || -> std::io::Result<()> {
-            // BrokenPipe means the child exited before reading all stdin — treat
-            // as success so a fast downstream command (e.g. `head -1`) doesn't
-            // surface a spurious I/O error.
-            if let Err(e) = child_stdin.write_all(&data)
-                && e.kind() != std::io::ErrorKind::BrokenPipe
-            {
-                return Err(e);
-            }
-            Ok(()) // drop closes the pipe
-        });
-        // Drain stdout/stderr while stdin is being written to avoid deadlock.
-        let stdout_thread = child.stdout.take().map(|mut pipe| {
-            thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut buf = Vec::new();
-                std::io::copy(&mut pipe, &mut buf)?;
-                Ok(buf)
-            })
-        });
-        let stderr_thread = child.stderr.take().map(|mut pipe| {
-            thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut buf = Vec::new();
-                std::io::copy(&mut pipe, &mut buf)?;
-                Ok(buf)
-            })
-        });
-
-        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-
-        stdin_thread
-            .join()
-            .unwrap_or_else(|_| Err(std::io::Error::other("stdin thread panicked")))
-            .map_err(ShellError::Io)?;
-
-        if let Some(handle) = stdout_thread {
-            let bytes = join_io_thread(handle, "stdout")?;
-            out.write_all(&bytes)?;
-        }
-        if let Some(handle) = stderr_thread {
-            let bytes = join_io_thread(handle, "stderr")?;
-            err.write_all(&bytes)?;
-        }
-
-        if !status.success() {
-            return Err(ShellError::NonZeroExit(status));
-        }
-    } else {
-        // No stdin data — same as the existing execute_executable path.
-        let stdout_thread = child.stdout.take().map(|mut pipe| {
-            thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut buf = Vec::new();
-                std::io::copy(&mut pipe, &mut buf)?;
-                Ok(buf)
-            })
-        });
-        let stderr_thread = child.stderr.take().map(|mut pipe| {
-            thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut buf = Vec::new();
-                std::io::copy(&mut pipe, &mut buf)?;
-                Ok(buf)
-            })
-        });
-
-        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-
-        if let Some(handle) = stdout_thread {
-            let bytes = join_io_thread(handle, "stdout")?;
-            out.write_all(&bytes)?;
-        }
-        if let Some(handle) = stderr_thread {
-            let bytes = join_io_thread(handle, "stderr")?;
-            err.write_all(&bytes)?;
-        }
-
-        if !status.success() {
-            return Err(ShellError::NonZeroExit(status));
-        }
-    }
-
-    Ok(None)
 }
 
 /// Core dispatch: all output goes to the provided `out` and `err` writers.
@@ -400,7 +287,7 @@ fn execute_with_writers(
 ) -> ShellResult<Option<ExitCode>> {
     let result = match &command {
         Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
-        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx),
+        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx, None),
         Command::Unrecognized(cmd) => {
             return Err(ShellError::CommandNotFound {
                 name: String::from_utf8_lossy(cmd).into_owned(),
@@ -512,7 +399,9 @@ fn execute_executable(
     out: &mut dyn std::io::Write,
     err: &mut dyn std::io::Write,
     ctx: &ShellCtx,
+    stdin_data: Option<&[u8]>,
 ) -> ShellResult<Option<ExitCode>> {
+    use std::io::Write as _;
     use std::process::Stdio;
     use std::thread;
 
@@ -520,17 +409,33 @@ fn execute_executable(
     let mut child = std::process::Command::new(executable.file_path())
         .args(args)
         .current_dir(&ctx.cwd)
+        .stdin(if stdin_data.is_some() { Stdio::piped() } else { Stdio::inherit() })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(ShellError::ExecutionFailed)?;
 
-    // Drain both pipes concurrently on separate threads to avoid deadlock:
-    // if the child fills one pipe's buffer while we are blocked reading the
-    // other, neither side can make progress.  `ChildStdout`/`ChildStderr` are
-    // `Send`, so they can be moved into threads safely.  We accumulate bytes
-    // into `Vec<u8>` and write them into the writers after joining — keeping
-    // the `?Send` writers exclusively on the calling thread.
+    // Spawn a stdin writer before draining stdout/stderr to avoid deadlock:
+    // the child may fill its stdout buffer before reading all stdin, so we
+    // must drain both concurrently.  `ChildStdin`/`ChildStdout`/`ChildStderr`
+    // are `Send`, so they can be moved into threads safely.
+    let stdin_thread = stdin_data
+        .zip(child.stdin.take())
+        .map(|(data, mut child_stdin)| {
+            let data = data.to_vec();
+            thread::spawn(move || -> std::io::Result<()> {
+                // BrokenPipe means the child exited before reading all stdin — treat
+                // as success so a fast downstream command (e.g. `head -1`) doesn't
+                // surface a spurious I/O error.
+                if let Err(e) = child_stdin.write_all(&data)
+                    && e.kind() != std::io::ErrorKind::BrokenPipe
+                {
+                    return Err(e);
+                }
+                Ok(()) // drop closes the pipe
+            })
+        });
+
     let stdout_thread = child.stdout.take().map(|mut pipe| {
         thread::spawn(move || -> std::io::Result<Vec<u8>> {
             let mut buf = Vec::new();
@@ -549,7 +454,13 @@ fn execute_executable(
     // Always wait on the child so it is reaped even when I/O copy fails.
     let status = child.wait().map_err(ShellError::ExecutionFailed)?;
 
-    // Collect thread results; propagate the first I/O error encountered.
+    if let Some(handle) = stdin_thread {
+        handle
+            .join()
+            .unwrap_or_else(|_| Err(std::io::Error::other("stdin thread panicked")))
+            .map_err(ShellError::Io)?;
+    }
+
     if let Some(handle) = stdout_thread {
         let bytes = join_io_thread(handle, "stdout")?;
         out.write_all(&bytes)?;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -123,11 +123,11 @@ pub fn execute(
 /// Execute a [`Pipeline`] (one or more `|`-connected commands).
 ///
 /// A single-stage pipeline delegates to [`execute`] unchanged.  A multi-stage
-/// pipeline runs each stage serially: the stdout of stage *i* is collected into
-/// a buffer, then fed as the stdin of stage *i+1*.  For executable stages the
-/// connection uses OS pipes; for built-in stages the buffer is wired via an
-/// in-memory cursor.  The last stage's stdout is written to `io` (or to a file
-/// if a per-stage redirect is present).
+/// pipeline runs each stage serially: the stdout of stage *i* is buffered then
+/// fed as stdin to stage *i+1*.  For executable stages the data is written into
+/// the child's stdin pipe; built-in stages do not currently consume piped stdin
+/// data.  The last stage's stdout is written to `io` (or to a file if a
+/// per-stage redirect is present).
 ///
 /// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
 pub fn execute_pipeline(

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -129,6 +129,9 @@ pub fn execute(
 /// data.  The last stage's stdout is written to `io` (or to a file if a
 /// per-stage redirect is present).
 ///
+/// Stdout buffering is intentional for this implementation — issue #28 will
+/// replace it with OS-level streaming pipes between concurrent processes.
+///
 /// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
 pub fn execute_pipeline(
     pipeline: Pipeline,
@@ -162,66 +165,55 @@ pub fn execute_pipeline(
         }
 
         // Intermediate stage: capture stdout for the next stage.
+        // POSIX: if this stage has a stdout redirect (`cmd > f | next`), honour
+        // it — write to the file and pass empty stdin to the next stage.
         let mut out_buf: Vec<u8> = Vec::new();
-        if let Some(prev) = stdin_buf.take() {
-            execute_stage_capture(
-                command, args, io, ctx, stderr_redirect, &prev, &mut out_buf,
-            )?;
-        } else {
-            execute_stage_capture_no_stdin(
-                command, args, io, ctx, stderr_redirect, &mut out_buf,
-            )?;
-        }
+        let prev = stdin_buf.take().unwrap_or_default();
+        execute_stage_capture(
+            command, args, io, ctx, stdout_redirect, stderr_redirect, &prev, &mut out_buf,
+        )?;
         stdin_buf = Some(out_buf);
     }
 
     Ok(None)
 }
 
-/// Run one pipeline stage, feeding `stdin_data` as the command's stdin and
-/// directing stdout to `out_buf`.  Stderr goes to `io`.
+/// Run one intermediate pipeline stage, feeding `stdin_data` as the command's
+/// stdin.  If `stdout_redirect` is `Some`, stdout goes to that file (POSIX
+/// semantics); otherwise it is captured into `out_buf` for the next stage.
+/// Stderr honours `stderr_redirect` or falls back to `io`.
+#[allow(clippy::too_many_arguments)]
 fn execute_stage_capture(
     command: Command,
     args: Args,
     io: &mut impl ShellIo,
     ctx: &mut ShellCtx,
+    stdout_redirect: Option<StdoutRedirection>,
     stderr_redirect: Option<StderrRedirection>,
     stdin_data: &[u8],
     out_buf: &mut Vec<u8>,
 ) -> ShellResult<Option<ExitCode>> {
+    let mut stdout_file: Option<std::fs::File> = stdout_redirect
+        .as_ref()
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+
     let mut stderr_file: Option<std::fs::File> = stderr_redirect
         .as_ref()
         .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
         .transpose()?;
 
+    let out_writer: &mut dyn std::io::Write = match stdout_file.as_mut() {
+        Some(f) => f,
+        None => out_buf,
+    };
     let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
         Some(f) => f,
         None => io.err_writer(),
     };
 
-    execute_stage_inner(command, args, out_buf, err_writer, ctx, Some(stdin_data))
-}
-
-/// Run the first pipeline stage (no stdin piped from prior stage), capturing stdout.
-fn execute_stage_capture_no_stdin(
-    command: Command,
-    args: Args,
-    io: &mut impl ShellIo,
-    ctx: &mut ShellCtx,
-    stderr_redirect: Option<StderrRedirection>,
-    out_buf: &mut Vec<u8>,
-) -> ShellResult<Option<ExitCode>> {
-    let mut stderr_file: Option<std::fs::File> = stderr_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
-        Some(f) => f,
-        None => io.err_writer(),
-    };
-
-    execute_stage_inner(command, args, out_buf, err_writer, ctx, None)
+    let stdin = if stdin_data.is_empty() { None } else { Some(stdin_data) };
+    execute_stage_inner(command, args, out_writer, err_writer, ctx, stdin)
 }
 
 /// Run the last pipeline stage, feeding `stdin_data` and honouring redirects.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,6 +14,7 @@ use crate::{
     exit::ExitCode,
     fs,
     io::ShellIo,
+    parser::Pipeline,
     redirect::{RedirectMode, StderrRedirection, StdoutRedirection},
 };
 
@@ -117,6 +118,275 @@ pub fn execute(
             execute_with_writers(command, args, out, err, ctx)
         }
     }
+}
+
+/// Execute a [`Pipeline`] (one or more `|`-connected commands).
+///
+/// A single-stage pipeline delegates to [`execute`] unchanged.  A multi-stage
+/// pipeline runs each stage serially: the stdout of stage *i* is collected into
+/// a buffer, then fed as the stdin of stage *i+1*.  For executable stages the
+/// connection uses OS pipes; for built-in stages the buffer is wired via an
+/// in-memory cursor.  The last stage's stdout is written to `io` (or to a file
+/// if a per-stage redirect is present).
+///
+/// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
+pub fn execute_pipeline(
+    pipeline: Pipeline,
+    io: &mut impl ShellIo,
+    ctx: &mut ShellCtx,
+) -> ShellResult<Option<ExitCode>> {
+    let mut stages = pipeline;
+
+    // Fast path: no pipe operators.
+    if stages.len() == 1 {
+        let (cmd, args, stdout_redir, stderr_redir) = stages.remove(0);
+        return execute(cmd, args, io, ctx, stdout_redir, stderr_redir);
+    }
+
+    // Multi-stage: carry the previous stage's captured stdout forward.
+    let mut stdin_buf: Option<Vec<u8>> = None;
+    let last_idx = stages.len() - 1;
+
+    for (i, (command, args, stdout_redirect, stderr_redirect)) in stages.into_iter().enumerate() {
+        let is_last = i == last_idx;
+
+        if is_last {
+            // Final stage: write to the shell's real I/O (honouring any redirect).
+            if let Some(buf) = stdin_buf.take() {
+                execute_stage_with_stdin(
+                    command, args, io, ctx, stdout_redirect, stderr_redirect, &buf,
+                )?;
+            } else {
+                execute(command, args, io, ctx, stdout_redirect, stderr_redirect)?;
+            }
+            return Ok(None);
+        }
+
+        // Intermediate stage: capture stdout for the next stage.
+        let mut out_buf: Vec<u8> = Vec::new();
+        if let Some(prev) = stdin_buf.take() {
+            execute_stage_capture(
+                command, args, io, ctx, stderr_redirect, &prev, &mut out_buf,
+            )?;
+        } else {
+            execute_stage_capture_no_stdin(
+                command, args, io, ctx, stderr_redirect, &mut out_buf,
+            )?;
+        }
+        stdin_buf = Some(out_buf);
+    }
+
+    Ok(None)
+}
+
+/// Run one pipeline stage, feeding `stdin_data` as the command's stdin and
+/// directing stdout to `out_buf`.  Stderr goes to `io`.
+fn execute_stage_capture(
+    command: Command,
+    args: Args,
+    io: &mut impl ShellIo,
+    ctx: &mut ShellCtx,
+    stderr_redirect: Option<StderrRedirection>,
+    stdin_data: &[u8],
+    out_buf: &mut Vec<u8>,
+) -> ShellResult<Option<ExitCode>> {
+    let mut stderr_file: Option<std::fs::File> = stderr_redirect
+        .as_ref()
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+
+    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
+        Some(f) => f,
+        None => io.err_writer(),
+    };
+
+    execute_stage_inner(command, args, out_buf, err_writer, ctx, Some(stdin_data))
+}
+
+/// Run the first pipeline stage (no stdin piped from prior stage), capturing stdout.
+fn execute_stage_capture_no_stdin(
+    command: Command,
+    args: Args,
+    io: &mut impl ShellIo,
+    ctx: &mut ShellCtx,
+    stderr_redirect: Option<StderrRedirection>,
+    out_buf: &mut Vec<u8>,
+) -> ShellResult<Option<ExitCode>> {
+    let mut stderr_file: Option<std::fs::File> = stderr_redirect
+        .as_ref()
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+
+    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
+        Some(f) => f,
+        None => io.err_writer(),
+    };
+
+    execute_stage_inner(command, args, out_buf, err_writer, ctx, None)
+}
+
+/// Run the last pipeline stage, feeding `stdin_data` and honouring redirects.
+fn execute_stage_with_stdin(
+    command: Command,
+    args: Args,
+    io: &mut impl ShellIo,
+    ctx: &mut ShellCtx,
+    stdout_redirect: Option<StdoutRedirection>,
+    stderr_redirect: Option<StderrRedirection>,
+    stdin_data: &[u8],
+) -> ShellResult<Option<ExitCode>> {
+    let mut stdout_file: Option<std::fs::File> = stdout_redirect
+        .as_ref()
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+
+    let mut stderr_file: Option<std::fs::File> = stderr_redirect
+        .as_ref()
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+
+    let (io_out, io_err) = io.writers();
+    let out_writer: &mut dyn std::io::Write = match stdout_file.as_mut() {
+        Some(f) => f,
+        None => io_out,
+    };
+    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
+        Some(f) => f,
+        None => io_err,
+    };
+
+    execute_stage_inner(command, args, out_writer, err_writer, ctx, Some(stdin_data))
+}
+
+/// Core dispatch for a pipeline stage: routes to builtin or executable, feeding
+/// `stdin_data` (if any) as the command's standard input.
+fn execute_stage_inner(
+    command: Command,
+    args: Args,
+    out: &mut dyn std::io::Write,
+    err: &mut dyn std::io::Write,
+    ctx: &mut ShellCtx,
+    stdin_data: Option<&[u8]>,
+) -> ShellResult<Option<ExitCode>> {
+    let result = match &command {
+        Command::BuiltIn(builtin) => {
+            // Builtins don't consume stdin from a pipe — they ignore it.
+            execute_builtin(builtin, args, out, err, ctx)
+        }
+        Command::Executable(executable) => {
+            execute_executable_with_stdin(executable, args, out, err, ctx, stdin_data)
+        }
+        Command::Unrecognized(cmd) => {
+            return Err(ShellError::CommandNotFound {
+                name: String::from_utf8_lossy(cmd).into_owned(),
+            })
+        }
+    };
+    result.map_err(|e| ShellError::InCommand { command, source: Box::new(e) })
+}
+
+/// Spawn an external command, optionally feeding `stdin_data` into its stdin,
+/// and capturing its stdout/stderr into the provided writers.
+fn execute_executable_with_stdin(
+    executable: &ExecutableCommand,
+    args: Args,
+    out: &mut dyn std::io::Write,
+    err: &mut dyn std::io::Write,
+    ctx: &ShellCtx,
+    stdin_data: Option<&[u8]>,
+) -> ShellResult<Option<ExitCode>> {
+    use std::io::Write as _;
+    use std::process::Stdio;
+    use std::thread;
+
+    let args = args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
+    let mut child = std::process::Command::new(executable.file_path())
+        .args(args)
+        .current_dir(&ctx.cwd)
+        .stdin(if stdin_data.is_some() { Stdio::piped() } else { Stdio::inherit() })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(ShellError::ExecutionFailed)?;
+
+    // Feed stdin data if present; do this before draining stdout/stderr to
+    // avoid a potential deadlock where the child blocks on stdout while we
+    // block writing stdin.
+    if let (Some(data), Some(mut child_stdin)) = (stdin_data, child.stdin.take()) {
+        let data = data.to_vec();
+        let stdin_thread = thread::spawn(move || -> std::io::Result<()> {
+            child_stdin.write_all(&data)?;
+            Ok(()) // drop flushes and closes the pipe
+        });
+        // Drain stdout/stderr while stdin is being written to avoid deadlock.
+        let stdout_thread = child.stdout.take().map(|mut pipe| {
+            thread::spawn(move || -> std::io::Result<Vec<u8>> {
+                let mut buf = Vec::new();
+                std::io::copy(&mut pipe, &mut buf)?;
+                Ok(buf)
+            })
+        });
+        let stderr_thread = child.stderr.take().map(|mut pipe| {
+            thread::spawn(move || -> std::io::Result<Vec<u8>> {
+                let mut buf = Vec::new();
+                std::io::copy(&mut pipe, &mut buf)?;
+                Ok(buf)
+            })
+        });
+
+        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+
+        stdin_thread
+            .join()
+            .unwrap_or_else(|_| Err(std::io::Error::other("stdin thread panicked")))
+            .map_err(ShellError::Io)?;
+
+        if let Some(handle) = stdout_thread {
+            let bytes = join_io_thread(handle, "stdout")?;
+            out.write_all(&bytes)?;
+        }
+        if let Some(handle) = stderr_thread {
+            let bytes = join_io_thread(handle, "stderr")?;
+            err.write_all(&bytes)?;
+        }
+
+        if !status.success() {
+            return Err(ShellError::NonZeroExit(status));
+        }
+    } else {
+        // No stdin data — same as the existing execute_executable path.
+        let stdout_thread = child.stdout.take().map(|mut pipe| {
+            thread::spawn(move || -> std::io::Result<Vec<u8>> {
+                let mut buf = Vec::new();
+                std::io::copy(&mut pipe, &mut buf)?;
+                Ok(buf)
+            })
+        });
+        let stderr_thread = child.stderr.take().map(|mut pipe| {
+            thread::spawn(move || -> std::io::Result<Vec<u8>> {
+                let mut buf = Vec::new();
+                std::io::copy(&mut pipe, &mut buf)?;
+                Ok(buf)
+            })
+        });
+
+        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+
+        if let Some(handle) = stdout_thread {
+            let bytes = join_io_thread(handle, "stdout")?;
+            out.write_all(&bytes)?;
+        }
+        if let Some(handle) = stderr_thread {
+            let bytes = join_io_thread(handle, "stderr")?;
+            err.write_all(&bytes)?;
+        }
+
+        if !status.success() {
+            return Err(ShellError::NonZeroExit(status));
+        }
+    }
+
+    Ok(None)
 }
 
 /// Core dispatch: all output goes to the provided `out` and `err` writers.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -152,14 +152,13 @@ pub fn execute_pipeline(
 
         if is_last {
             // Final stage: write to the shell's real I/O (honouring any redirect).
-            if let Some(buf) = stdin_buf.take() {
+            return if let Some(buf) = stdin_buf.take() {
                 execute_stage_with_stdin(
                     command, args, io, ctx, stdout_redirect, stderr_redirect, &buf,
-                )?;
+                )
             } else {
-                execute(command, args, io, ctx, stdout_redirect, stderr_redirect)?;
-            }
-            return Ok(None);
+                execute(command, args, io, ctx, stdout_redirect, stderr_redirect)
+            };
         }
 
         // Intermediate stage: capture stdout for the next stage.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -165,10 +165,13 @@ pub fn execute_pipeline(
         // Intermediate stage: capture stdout for the next stage.
         // POSIX: if this stage has a stdout redirect (`cmd > f | next`), honour
         // it — write to the file and pass empty stdin to the next stage.
+        // Pass `prev` as `Option<&[u8]>`: `None` on the first stage so the
+        // command can inherit terminal stdin; `Some(&[])` on subsequent stages
+        // so a command after a redirect gets a closed (empty) pipe, not the terminal.
         let mut out_buf: Vec<u8> = Vec::new();
-        let prev = stdin_buf.take().unwrap_or_default();
+        let prev = stdin_buf.take();
         execute_stage_capture(
-            command, args, io, ctx, stdout_redirect, stderr_redirect, &prev, &mut out_buf,
+            command, args, io, ctx, stdout_redirect, stderr_redirect, prev.as_deref(), &mut out_buf,
         )?;
         stdin_buf = Some(out_buf);
     }
@@ -188,7 +191,7 @@ fn execute_stage_capture(
     ctx: &mut ShellCtx,
     stdout_redirect: Option<StdoutRedirection>,
     stderr_redirect: Option<StderrRedirection>,
-    stdin_data: &[u8],
+    stdin_data: Option<&[u8]>,
     out_buf: &mut Vec<u8>,
 ) -> ShellResult<Option<ExitCode>> {
     let mut stdout_file: Option<std::fs::File> = stdout_redirect
@@ -210,8 +213,7 @@ fn execute_stage_capture(
         None => io.err_writer(),
     };
 
-    let stdin = if stdin_data.is_empty() { None } else { Some(stdin_data) };
-    execute_stage_inner(command, args, out_writer, err_writer, ctx, stdin)
+    execute_stage_inner(command, args, out_writer, err_writer, ctx, stdin_data)
 }
 
 /// Run the last pipeline stage, feeding `stdin_data` and honouring redirects.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -306,8 +306,15 @@ fn execute_executable_with_stdin(
     if let (Some(data), Some(mut child_stdin)) = (stdin_data, child.stdin.take()) {
         let data = data.to_vec();
         let stdin_thread = thread::spawn(move || -> std::io::Result<()> {
-            child_stdin.write_all(&data)?;
-            Ok(()) // drop flushes and closes the pipe
+            // BrokenPipe means the child exited before reading all stdin — treat
+            // as success so a fast downstream command (e.g. `head -1`) doesn't
+            // surface a spurious I/O error.
+            if let Err(e) = child_stdin.write_all(&data)
+                && e.kind() != std::io::ErrorKind::BrokenPipe
+            {
+                return Err(e);
+            }
+            Ok(()) // drop closes the pipe
         });
         // Drain stdout/stderr while stdin is being written to avoid deadlock.
         let stdout_thread = child.stdout.take().map(|mut pipe| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,8 +11,20 @@ use crate::env::get_path_files;
 use crate::error::ShellError;
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 
-/// Parse a raw input line into a [`Command`], its argument list, an optional
-/// stdout [`Redirection`], and an optional stderr [`Redirection`].
+/// One stage of a pipeline: the command to run, its arguments, and any
+/// per-stage redirections.
+pub type PipelineStage = (Command, Args, Option<StdoutRedirection>, Option<StderrRedirection>);
+
+/// A parsed pipeline — one [`PipelineStage`] per `|`-separated segment.
+///
+/// A single command with no `|` is represented as a `Vec` of length 1.
+pub type Pipeline = Vec<PipelineStage>;
+
+/// Parse a raw input line into a [`Pipeline`].
+///
+/// The input is first split on unquoted `|` characters into segments; each
+/// segment is then parsed into a [`PipelineStage`] exactly as a standalone
+/// command would be.
 ///
 /// Recognised redirect operators and their meanings:
 ///
@@ -26,17 +38,18 @@ use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 /// When the same fd appears more than once, the **last** operator wins.
 /// Only unquoted redirect operators are recognised; an operator character that
 /// appears inside quotes is treated as a literal argument character.
-pub fn parse(
-    buffer: &[u8],
-) -> Result<
-    (
-        Command,
-        Args,
-        Option<StdoutRedirection>,
-        Option<StderrRedirection>,
-    ),
-    ShellError,
-> {
+pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
+    let segments = split_pipeline_segments(buffer);
+    let mut pipeline = Vec::with_capacity(segments.len());
+    for segment in segments {
+        pipeline.push(parse_segment(&segment)?);
+    }
+    Ok(pipeline)
+}
+
+/// Parse a single pipeline segment (bytes between `|` operators) into a
+/// [`PipelineStage`].
+fn parse_segment(buffer: &[u8]) -> Result<PipelineStage, ShellError> {
     let (command, raw_args) = split_command_and_args(buffer)?;
     let command = parse_command(&command);
 
@@ -50,6 +63,59 @@ pub fn parse(
         })
         .collect();
     Ok((command, args, stdout_redirect, stderr_redirect))
+}
+
+/// Split `buffer` on unquoted `|` characters, returning a `Vec` of raw
+/// byte slices — one per pipeline segment.  Quoted `|` characters are never
+/// treated as separators.
+fn split_pipeline_segments(buffer: &[u8]) -> Vec<Vec<u8>> {
+    let mut segments: Vec<Vec<u8>> = Vec::new();
+    let mut current: Vec<u8> = Vec::new();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut i = 0;
+
+    while i < buffer.len() {
+        let byte = buffer[i];
+        if in_single_quote {
+            if byte == b'\'' {
+                in_single_quote = false;
+            }
+            current.push(byte);
+        } else if in_double_quote {
+            if byte == b'"' {
+                in_double_quote = false;
+            } else if byte == b'\\' && i + 1 < buffer.len() {
+                // Keep the backslash and next char so `split_command_and_args`
+                // can re-process them correctly per-segment.
+                current.push(byte);
+                i += 1;
+                current.push(buffer[i]);
+                i += 1;
+                continue;
+            }
+            current.push(byte);
+        } else if byte == b'\'' {
+            in_single_quote = true;
+            current.push(byte);
+        } else if byte == b'"' {
+            in_double_quote = true;
+            current.push(byte);
+        } else if byte == b'\\' && i + 1 < buffer.len() {
+            // Outside quotes: consume `\X` as a pair so `|` after `\` is not
+            // treated as a separator (e.g. `echo \| foo` should not split).
+            current.push(byte);
+            i += 1;
+            current.push(buffer[i]);
+        } else if byte == b'|' {
+            segments.push(std::mem::take(&mut current));
+        } else {
+            current.push(byte);
+        }
+        i += 1;
+    }
+    segments.push(current);
+    segments
 }
 
 /// Raw argument token: byte content and its quoting style.
@@ -640,12 +706,19 @@ mod tests {
         assert!(!err.is_fatal());
     }
 
+    // Helper: parse a single-stage command (no `|`) and extract the one stage.
+    fn parse_single(input: &[u8]) -> PipelineStage {
+        let mut pipeline = parse(input).unwrap();
+        assert_eq!(pipeline.len(), 1, "expected exactly one pipeline stage");
+        pipeline.remove(0)
+    }
+
     // --- Redirect extraction tests ---
 
     #[test]
     fn test_parse_redirect_gt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello > out.txt").unwrap();
+            parse_single(b"echo hello > out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -659,7 +732,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_1gt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello 1> out.txt").unwrap();
+            parse_single(b"echo hello 1> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -673,7 +746,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_gtgt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello >> out.txt").unwrap();
+            parse_single(b"echo hello >> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -687,7 +760,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_1gtgt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello 1>> out.txt").unwrap();
+            parse_single(b"echo hello 1>> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -701,7 +774,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_2gt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello 2> err.txt").unwrap();
+            parse_single(b"echo hello 2> err.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -715,7 +788,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_2gtgt() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"exit notanumber 2>> err.txt").unwrap();
+            parse_single(b"exit notanumber 2>> err.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["notanumber"]
@@ -729,7 +802,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_last_wins_stdout() {
         let (_, args, stdout_redirect, _) =
-            parse(b"echo hi > first.txt >> last.txt").unwrap();
+            parse_single(b"echo hi > first.txt >> last.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hi"]
@@ -742,7 +815,7 @@ mod tests {
     #[test]
     fn test_parse_redirect_last_wins_stderr() {
         let (_, args, _, stderr_redirect) =
-            parse(b"echo hi 2> first.txt 2>> last.txt").unwrap();
+            parse_single(b"echo hi 2> first.txt 2>> last.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hi"]
@@ -754,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, stdout_redirect, _) = parse(b"echo >").unwrap();
+        let (_, args, stdout_redirect, _) = parse_single(b"echo >");
         assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -765,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
-        let (_, args, stdout_redirect, _) = parse(b"echo >>").unwrap();
+        let (_, args, stdout_redirect, _) = parse_single(b"echo >>");
         assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -776,7 +849,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, _, stderr_redirect) = parse(b"echo 2>").unwrap();
+        let (_, args, _, stderr_redirect) = parse_single(b"echo 2>");
         assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -787,7 +860,7 @@ mod tests {
 
     #[test]
     fn test_parse_mixed_quoted_operator_not_a_redirect() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse(b"echo 1'>'").unwrap();
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo 1'>'");
         assert!(
             stdout_redirect.is_none(),
             "mixed-quoted 1'>' must not trigger a redirect"
@@ -801,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_append_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, _, stderr_redirect) = parse(b"echo 2>>").unwrap();
+        let (_, args, _, stderr_redirect) = parse_single(b"echo 2>>");
         assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
@@ -813,12 +886,66 @@ mod tests {
     #[test]
     fn test_parse_no_redirect() {
         let (_, args, stdout_redirect, stderr_redirect) =
-            parse(b"echo hello world").unwrap();
+            parse_single(b"echo hello world");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]
         );
         assert!(stdout_redirect.is_none());
         assert!(stderr_redirect.is_none());
+    }
+
+    // --- Pipeline splitting tests ---
+
+    #[test]
+    fn test_pipeline_single_command_gives_one_stage() {
+        let p = parse(b"echo hello").unwrap();
+        assert_eq!(p.len(), 1);
+    }
+
+    #[test]
+    fn test_pipeline_two_commands_gives_two_stages() {
+        let p = parse(b"echo foo | cat").unwrap();
+        assert_eq!(p.len(), 2);
+        let (cmd0, args0, _, _) = &p[0];
+        let (cmd1, args1, _, _) = &p[1];
+        assert_eq!(cmd0.to_string(), "echo");
+        assert_eq!(
+            args0.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec!["foo"]
+        );
+        assert_eq!(cmd1.to_string(), "cat");
+        assert!(args1.is_empty());
+    }
+
+    #[test]
+    fn test_pipeline_quoted_pipe_is_not_separator() {
+        let p = parse(b"echo 'foo | bar'").unwrap();
+        assert_eq!(p.len(), 1, "quoted | must not split the pipeline");
+        let (_, args, _, _) = &p[0];
+        assert_eq!(
+            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec!["foo | bar"]
+        );
+    }
+
+    #[test]
+    fn test_pipeline_double_quoted_pipe_is_not_separator() {
+        let p = parse(b"echo \"foo | bar\"").unwrap();
+        assert_eq!(p.len(), 1, "double-quoted | must not split the pipeline");
+        let (_, args, _, _) = &p[0];
+        assert_eq!(
+            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
+            vec!["foo | bar"]
+        );
+    }
+
+    #[test]
+    fn test_pipeline_last_stage_redirect() {
+        let p = parse(b"echo foo | cat > out.txt").unwrap();
+        assert_eq!(p.len(), 2);
+        let (_, _, stdout_redir, _) = &p[1];
+        let r = stdout_redir.as_ref().expect("last stage should have redirect");
+        assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,8 +44,12 @@ pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
     for segment in segments {
         // Compute the segment's byte offset within the original buffer via
         // pointer arithmetic so that error spans are relative to the full line.
+        // Also account for leading whitespace that `split_command_and_args`
+        // trims internally — without this correction, spans in later pipeline
+        // stages would be off by the number of leading spaces after `|`.
         let offset = segment.as_ptr() as usize - buffer.as_ptr() as usize;
-        pipeline.push(parse_segment(segment).map_err(|e| adjust_span(e, offset))?);
+        let leading_ws = segment.len() - segment.trim_ascii_start().len();
+        pipeline.push(parse_segment(segment).map_err(|e| adjust_span(e, offset + leading_ws))?);
     }
     Ok(pipeline)
 }
@@ -707,6 +711,25 @@ mod tests {
         let result = split_command_and_args(b"echo \"unterminated");
         let err = result.unwrap_err();
         assert!(!err.is_fatal());
+    }
+
+    #[test]
+    fn test_pipeline_unclosed_quote_span_accounts_for_leading_whitespace() {
+        // The second segment has one leading space after `|`.
+        // The `"` opens at byte 5 within the trimmed segment `echo "bar`,
+        // which starts at byte 10 in the full input (`echo foo |`).
+        // With the leading-space correction (+1), the span should be at byte 16.
+        let input = b"echo foo | echo \"bar";
+        let err = parse(input).unwrap_err();
+        if let ShellError::UnclosedQuote { span, .. } = err {
+            assert_eq!(
+                span.offset(),
+                16,
+                "quote `\"` is at byte 16 in the full input"
+            );
+        } else {
+            panic!("expected UnclosedQuote, got: {err:?}");
+        }
     }
 
     // Helper: parse a single-stage command (no `|`) and extract the one stage.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,9 +42,24 @@ pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
     let segments = split_pipeline_segments(buffer);
     let mut pipeline = Vec::with_capacity(segments.len());
     for segment in segments {
-        pipeline.push(parse_segment(segment)?);
+        // Compute the segment's byte offset within the original buffer via
+        // pointer arithmetic so that error spans are relative to the full line.
+        let offset = segment.as_ptr() as usize - buffer.as_ptr() as usize;
+        pipeline.push(parse_segment(segment).map_err(|e| adjust_span(e, offset))?);
     }
     Ok(pipeline)
+}
+
+/// Shift a [`ShellError::UnclosedQuote`] span by `delta` bytes so it is
+/// relative to the full input line rather than the per-segment slice.
+fn adjust_span(error: ShellError, delta: usize) -> ShellError {
+    match error {
+        ShellError::UnclosedQuote { style, span } => ShellError::UnclosedQuote {
+            style,
+            span: SourceSpan::from((span.offset() + delta, span.len())),
+        },
+        other => other,
+    }
 }
 
 /// Parse a single pipeline segment (bytes between `|` operators) into a

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,7 @@ pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
     let segments = split_pipeline_segments(buffer);
     let mut pipeline = Vec::with_capacity(segments.len());
     for segment in segments {
-        pipeline.push(parse_segment(&segment)?);
+        pipeline.push(parse_segment(segment)?);
     }
     Ok(pipeline)
 }
@@ -65,12 +65,13 @@ fn parse_segment(buffer: &[u8]) -> Result<PipelineStage, ShellError> {
     Ok((command, args, stdout_redirect, stderr_redirect))
 }
 
-/// Split `buffer` on unquoted `|` characters, returning a `Vec` of owned
-/// byte buffers — one per pipeline segment.  Quoted `|` characters are never
-/// treated as separators.
-fn split_pipeline_segments(buffer: &[u8]) -> Vec<Vec<u8>> {
-    let mut segments: Vec<Vec<u8>> = Vec::new();
-    let mut current: Vec<u8> = Vec::new();
+/// Split `buffer` on unquoted `|` characters, returning slices into the
+/// original buffer — one per pipeline segment.  Quoted `|` characters are
+/// never treated as separators.  No copying is performed; the returned slices
+/// borrow directly from `buffer`.
+fn split_pipeline_segments(buffer: &[u8]) -> Vec<&[u8]> {
+    let mut segments: Vec<&[u8]> = Vec::new();
+    let mut seg_start = 0;
     let mut in_single_quote = false;
     let mut in_double_quote = false;
     let mut i = 0;
@@ -81,40 +82,27 @@ fn split_pipeline_segments(buffer: &[u8]) -> Vec<Vec<u8>> {
             if byte == b'\'' {
                 in_single_quote = false;
             }
-            current.push(byte);
         } else if in_double_quote {
             if byte == b'"' {
                 in_double_quote = false;
             } else if byte == b'\\' && i + 1 < buffer.len() {
-                // Keep the backslash and next char so `split_command_and_args`
-                // can re-process them correctly per-segment.
-                current.push(byte);
-                i += 1;
-                current.push(buffer[i]);
-                i += 1;
-                continue;
+                i += 1; // skip the escaped char; both bytes remain in the slice
             }
-            current.push(byte);
         } else if byte == b'\'' {
             in_single_quote = true;
-            current.push(byte);
         } else if byte == b'"' {
             in_double_quote = true;
-            current.push(byte);
         } else if byte == b'\\' && i + 1 < buffer.len() {
-            // Outside quotes: consume `\X` as a pair so `|` after `\` is not
-            // treated as a separator (e.g. `echo \| foo` should not split).
-            current.push(byte);
+            // Outside quotes: skip `\X` as a pair so a `|` after `\` is not
+            // treated as a separator (e.g. `echo \| foo` must not split).
             i += 1;
-            current.push(buffer[i]);
         } else if byte == b'|' {
-            segments.push(std::mem::take(&mut current));
-        } else {
-            current.push(byte);
+            segments.push(&buffer[seg_start..i]);
+            seg_start = i + 1;
         }
         i += 1;
     }
-    segments.push(current);
+    segments.push(&buffer[seg_start..]);
     segments
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,8 +65,8 @@ fn parse_segment(buffer: &[u8]) -> Result<PipelineStage, ShellError> {
     Ok((command, args, stdout_redirect, stderr_redirect))
 }
 
-/// Split `buffer` on unquoted `|` characters, returning a `Vec` of raw
-/// byte slices — one per pipeline segment.  Quoted `|` characters are never
+/// Split `buffer` on unquoted `|` characters, returning a `Vec` of owned
+/// byte buffers — one per pipeline segment.  Quoted `|` characters are never
 /// treated as separators.
 fn split_pipeline_segments(buffer: &[u8]) -> Vec<Vec<u8>> {
     let mut segments: Vec<Vec<u8>> = Vec::new();

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -132,8 +132,8 @@ impl<IO: ShellIo> Shell<IO> {
 
     /// Execute a single parsed command, returning an optional exit code.
     ///
-    /// This is a convenience wrapper around [`execute_pipeline`] for callers
-    /// that already have a decomposed command.
+    /// Calls [`executor::execute`] directly; for callers that already hold a
+    /// decomposed command and do not need pipeline machinery.
     pub fn execute_command(
         &mut self,
         command: Command,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -76,21 +76,15 @@ impl<IO: ShellIo> Shell<IO> {
             }
 
             let make_src = || String::from_utf8_lossy(buffer).into_owned();
-            let (command, args, stdout_redirect, stderr_redirect) =
-                match parser::parse(buffer) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        let report = miette::Report::new(e).with_source_code(make_src());
-                        writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
-                        continue;
-                    }
-                };
-            match self.execute_command(
-                command,
-                args,
-                stdout_redirect,
-                stderr_redirect,
-            ) {
+            let pipeline = match parser::parse(buffer) {
+                Ok(r) => r,
+                Err(e) => {
+                    let report = miette::Report::new(e).with_source_code(make_src());
+                    writeln!(self.io.borrow_mut().err_writer(), "{report:?}").into_diagnostic()?;
+                    continue;
+                }
+            };
+            match self.execute_pipeline(pipeline) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
@@ -116,14 +110,11 @@ impl<IO: ShellIo> Shell<IO> {
                 continue;
             }
 
-            let (command, args, stdout_redirect, stderr_redirect) = parser::parse(buffer)
-                .map_err(|e| {
-                    miette::Report::new(e)
-                        .with_source_code(String::from_utf8_lossy(buffer).into_owned())
-                })?;
-            if let Some(exit_code) =
-                self.execute_command(command, args, stdout_redirect, stderr_redirect)?
-            {
+            let pipeline = parser::parse(buffer).map_err(|e| {
+                miette::Report::new(e)
+                    .with_source_code(String::from_utf8_lossy(buffer).into_owned())
+            })?;
+            if let Some(exit_code) = self.execute_pipeline(pipeline)? {
                 return Ok(exit_code);
             }
         }
@@ -131,7 +122,18 @@ impl<IO: ShellIo> Shell<IO> {
         Ok(ExitCode::SUCCESS)
     }
 
+    /// Execute a parsed [`Pipeline`], returning an optional exit code.
+    pub fn execute_pipeline(
+        &mut self,
+        pipeline: parser::Pipeline,
+    ) -> ShellResult<Option<ExitCode>> {
+        executor::execute_pipeline(pipeline, &mut *self.io.borrow_mut(), &mut self.ctx)
+    }
+
     /// Execute a single parsed command, returning an optional exit code.
+    ///
+    /// This is a convenience wrapper around [`execute_pipeline`] for callers
+    /// that already have a decomposed command.
     pub fn execute_command(
         &mut self,
         command: Command,

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -2,6 +2,7 @@ mod harness;
 
 use harness::ShellTest;
 
+#[cfg(unix)]
 #[test]
 fn test_basic_pipeline_echo_cat() {
     let result = ShellTest::new()
@@ -10,6 +11,7 @@ fn test_basic_pipeline_echo_cat() {
     result.assert_output_contains("hello");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_pipeline_with_wc_l() {
     // `echo` produces one line; `wc -l` should report 1.
@@ -24,6 +26,7 @@ fn test_pipeline_with_wc_l() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn test_pipeline_builtin_output_piped_to_cat() {
     let result = ShellTest::new()
@@ -32,6 +35,7 @@ fn test_pipeline_builtin_output_piped_to_cat() {
     result.assert_output_contains("piped content");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_pipeline_last_stage_redirect() {
     let result = ShellTest::new()
@@ -67,6 +71,7 @@ fn test_pipeline_double_quoted_pipe_is_literal() {
     result.assert_output_contains("foo | bar");
 }
 
+#[cfg(unix)]
 #[test]
 fn test_pipeline_pwd_piped_to_grep() {
     let result = ShellTest::new()

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -66,3 +66,21 @@ fn test_pipeline_double_quoted_pipe_is_literal() {
         .run();
     result.assert_output_contains("foo | bar");
 }
+
+#[test]
+fn test_pipeline_pwd_piped_to_grep() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("pwd | grep /")
+        .run();
+    result.assert_output_contains("/");
+}
+
+#[test]
+fn test_pipeline_last_stage_exit_code_propagates() {
+    // `exit 0` as the last stage of a pipeline must cause the shell to exit.
+    let result = ShellTest::new()
+        .script("echo foo | exit 0")
+        .run();
+    assert_eq!(result.exit_code(), 0);
+}

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -1,0 +1,68 @@
+mod harness;
+
+use harness::ShellTest;
+
+#[test]
+fn test_basic_pipeline_echo_cat() {
+    let result = ShellTest::new()
+        .script("echo hello | cat")
+        .run();
+    result.assert_output_contains("hello");
+}
+
+#[test]
+fn test_pipeline_with_wc_l() {
+    // `echo` produces one line; `wc -l` should report 1.
+    let result = ShellTest::new()
+        .script("echo hello | wc -l")
+        .run();
+    let output = result.output().trim().to_string();
+    // wc -l output may include leading whitespace on some platforms
+    assert!(
+        output.contains('1'),
+        "expected wc -l to report 1 line, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_pipeline_builtin_output_piped_to_cat() {
+    let result = ShellTest::new()
+        .script("echo 'piped content' | cat")
+        .run();
+    result.assert_output_contains("piped content");
+}
+
+#[test]
+fn test_pipeline_last_stage_redirect() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo foo | cat > out.txt")
+        .run();
+
+    let home = result.home_dir().expect("isolated home");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("redirect file should exist");
+    assert_eq!(contents.trim(), "foo", "pipeline output should be in the file");
+    // Terminal stdout may contain the prompt but must not contain the piped data.
+    assert!(
+        !result.output().contains("foo"),
+        "piped data must not appear on terminal stdout when redirected: {:?}",
+        result.output()
+    );
+}
+
+#[test]
+fn test_pipeline_quoted_pipe_is_literal() {
+    let result = ShellTest::new()
+        .script("echo 'foo | bar'")
+        .run();
+    result.assert_output_contains("foo | bar");
+}
+
+#[test]
+fn test_pipeline_double_quoted_pipe_is_literal() {
+    let result = ShellTest::new()
+        .script("echo \"foo | bar\"")
+        .run();
+    result.assert_output_contains("foo | bar");
+}


### PR DESCRIPTION
$(cat <<'EOF'
Implements the `|` operator by threading a `Pipeline` type (a `Vec<PipelineStage>`) through the parser, executor, and shell. The parser splits input on unquoted `|` before tokenizing each segment, so quoted `|` characters are always treated as literals. The executor runs stages serially — capturing each stage's stdout into a buffer and feeding it as stdin to the next stage; executable stages use piped stdin with concurrent thread draining to avoid deadlock. Per-stage stdout redirects compose naturally (`echo foo | cat > out.txt` writes to the file). Single-command inputs take the fast path through the existing `execute()` function with no overhead.

Closes #27
EOF
)