### PR TITLE
test: add 3+ command pipeline integration tests

### DIFF
--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -89,3 +89,65 @@ fn test_pipeline_last_stage_exit_code_propagates() {
         .run();
     assert_eq!(result.exit_code(), 0);
 }
+
+// --- 3+ command pipeline tests (issue #28) ---
+
+#[cfg(unix)]
+#[test]
+fn test_three_stage_pipeline_passthrough() {
+    let result = ShellTest::new()
+        .script("echo hello | cat | cat")
+        .run();
+    result.assert_output_contains("hello");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_four_stage_pipeline_passthrough() {
+    let result = ShellTest::new()
+        .script("echo hello | cat | cat | cat")
+        .run();
+    result.assert_output_contains("hello");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_three_stage_pipeline_transforms_data() {
+    // tr translates 'h' → 'H'; cat passes it through
+    let result = ShellTest::new()
+        .script("echo hello | tr h H | cat")
+        .run();
+    result.assert_output_contains("Hello");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_three_stage_pipeline_echo_cat_wc() {
+    // "hello\n" is 6 bytes; wc -c should report 6
+    let result = ShellTest::new()
+        .script("echo hello | cat | wc -c")
+        .run();
+    let output = result.output().trim().to_string();
+    assert!(
+        output.contains('6'),
+        "expected wc -c to report 6 bytes, got: {output:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_three_stage_pipeline_with_final_redirect() {
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo foo | cat | cat > out.txt")
+        .run();
+
+    let home = result.home_dir().expect("isolated home");
+    let contents = std::fs::read_to_string(home.join("out.txt"))
+        .expect("redirect file should exist");
+    assert_eq!(contents.trim(), "foo");
+    assert!(
+        !result.output().contains("foo"),
+        "piped data must not appear on terminal stdout when redirected"
+    );
+}

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -127,11 +127,14 @@ fn test_three_stage_pipeline_echo_cat_wc() {
     let result = ShellTest::new()
         .script("echo hello | cat | wc -c")
         .run();
-    let output = result.output().trim().to_string();
-    assert!(
-        output.contains('6'),
-        "expected wc -c to report 6 bytes, got: {output:?}"
-    );
+    let output = result.output();
+    // wc -c output may be padded and appears alongside shell prompts in captured output;
+    // scan tokens for the first that parses as an integer byte count.
+    let count: usize = output
+        .split_whitespace()
+        .find_map(|t| t.parse().ok())
+        .unwrap_or_else(|| panic!("expected wc -c output to contain a byte count, got: {output:?}"));
+    assert_eq!(count, 6, "wc -c should report 6 bytes for 'hello\\n', got: {output:?}");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
The existing `execute_pipeline` loop already handles chains of arbitrary length, but `tests/pipeline.rs` only covered two-command pipelines. This PR adds five integration tests that exercise 3- and 4-stage pipelines, satisfying the acceptance criteria in issue #28: passthrough via two intermediate `cat` stages, a four-stage chain, data transformation with `tr`, byte counting with `wc -c`, and a three-stage pipeline with a final stdout redirect.

Closes #28