### PR TITLE
test: verify builtins participate in pipelines at any position

### DIFF
--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -154,3 +154,29 @@ fn test_three_stage_pipeline_with_final_redirect() {
         "piped data must not appear on terminal stdout when redirected"
     );
 }
+
+// --- Builtins at any position in a pipeline (issue #29) ---
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_builtin_in_middle() {
+    // pwd is a builtin in the middle stage; it ignores piped stdin and emits cwd.
+    // grep filters for '/' which is present in any absolute path.
+    let result = ShellTest::new()
+        .with_isolated_home()
+        .script("echo ignored | pwd | grep /")
+        .run();
+    result.assert_output_contains("/");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_builtin_receives_piped_stdin() {
+    // A builtin at the receiving end of a pipe must not stall or error even
+    // though none of the current builtins consume stdin.  echo ignores its
+    // piped stdin and still emits its own arguments.
+    let result = ShellTest::new()
+        .script("echo upstream | echo downstream")
+        .run();
+    result.assert_output_contains("downstream");
+}

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -166,7 +166,15 @@ fn test_pipeline_builtin_in_middle() {
         .with_isolated_home()
         .script("echo ignored | pwd | grep /")
         .run();
-    result.assert_output_contains("/");
+    let output = result.output();
+    assert!(
+        output.contains('/'),
+        "expected piped pwd output to contain '/', got: {output:?}"
+    );
+    assert!(
+        !output.contains("ignored"),
+        "upstream builtin output must be piped, not written to terminal stdout: {output:?}"
+    );
 }
 
 #[cfg(unix)]
@@ -179,4 +187,8 @@ fn test_pipeline_builtin_receives_piped_stdin() {
         .script("echo upstream | echo downstream")
         .run();
     result.assert_output_contains("downstream");
+    assert!(
+        !result.output().contains("upstream"),
+        "upstream builtin output must be routed into the pipe, not leaked to terminal stdout"
+    );
 }


### PR DESCRIPTION
The executor already routes builtin commands through `execute_stage_inner` with the correct writer, so builtins work in pipelines without any code changes. This PR adds integration tests that explicitly cover the acceptance criteria from issue #29:

- `test_pipeline_builtin_in_middle`: 3-stage pipeline `echo ignored | pwd | grep /` — verifies a builtin (`pwd`) in the middle stage produces output that flows to the next stage
- `test_pipeline_builtin_receives_piped_stdin`: `echo upstream | echo downstream` — verifies a builtin at the receiving end of a pipe doesn't stall and still emits its own output

Closes #29