### PR TITLE
fix: make pipeline fail-fast explicit with exit code propagation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -150,8 +150,8 @@ impl ShellError {
     }
 
     /// Extract the [`ExitStatus`] if this error (or its wrapped source) is a
-    /// [`ShellError::NonZeroExit`].  Used by the pipeline executor to collect
-    /// per-stage exit codes without pattern-matching through the `InCommand`
+    /// [`ShellError::NonZeroExit`].  Useful for callers that need to inspect
+    /// stage exit codes without pattern-matching through the `InCommand`
     /// wrapper at each call site.
     pub fn as_exit_status(&self) -> Option<ExitStatus> {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,6 +148,18 @@ impl ShellError {
             _ => false,
         }
     }
+
+    /// Extract the [`ExitStatus`] if this error (or its wrapped source) is a
+    /// [`ShellError::NonZeroExit`].  Used by the pipeline executor to collect
+    /// per-stage exit codes without pattern-matching through the `InCommand`
+    /// wrapper at each call site.
+    pub fn as_exit_status(&self) -> Option<ExitStatus> {
+        match self {
+            ShellError::NonZeroExit(s) => Some(*s),
+            ShellError::InCommand { source, .. } => source.as_exit_status(),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -222,6 +234,34 @@ mod tests {
             span: SourceSpan::from((5, 1)),
         };
         assert_eq!(err.to_string(), "unclosed Double quote");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_as_exit_status_non_zero_exit() {
+        use std::os::unix::process::ExitStatusExt;
+        let status = ExitStatus::from_raw(1 << 8);
+        let err = ShellError::NonZeroExit(status);
+        assert_eq!(err.as_exit_status(), Some(status));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_as_exit_status_in_command_wraps_non_zero() {
+        use std::os::unix::process::ExitStatusExt;
+        let status = ExitStatus::from_raw(2 << 8);
+        let inner = ShellError::NonZeroExit(status);
+        let err = ShellError::InCommand {
+            command: Command::Unrecognized(b"foo".to_vec()),
+            source: Box::new(inner),
+        };
+        assert_eq!(err.as_exit_status(), Some(status));
+    }
+
+    #[test]
+    fn test_as_exit_status_other_variants_return_none() {
+        let err = ShellError::CommandNotFound { name: "foo".to_string() };
+        assert_eq!(err.as_exit_status(), None);
     }
 
     #[test]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -170,6 +170,9 @@ pub fn execute_pipeline(
         // so a command after a redirect gets a closed (empty) pipe, not the terminal.
         let mut out_buf: Vec<u8> = Vec::new();
         let prev = stdin_buf.take();
+        // Fail-fast: any non-zero exit from an intermediate stage aborts the
+        // pipeline immediately.  The `?` propagates both NonZeroExit and fatal
+        // errors; the REPL in shell.rs distinguishes them via `is_fatal()`.
         execute_stage_capture(
             command, args, io, ctx, stdout_redirect, stderr_redirect, prev.as_deref(), &mut out_buf,
         )?;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -170,9 +170,13 @@ pub fn execute_pipeline(
         // so a command after a redirect gets a closed (empty) pipe, not the terminal.
         let mut out_buf: Vec<u8> = Vec::new();
         let prev = stdin_buf.take();
-        // Fail-fast: any non-zero exit from an intermediate stage aborts the
-        // pipeline immediately.  The `?` propagates both NonZeroExit and fatal
-        // errors; the REPL in shell.rs distinguishes them via `is_fatal()`.
+        // Fail-fast for the current serial, buffered pipeline model: any
+        // non-zero exit from an intermediate stage aborts the pipeline
+        // immediately.  This is safe because later stages have not been
+        // spawned yet.  The `?` propagates both NonZeroExit and fatal errors;
+        // the REPL in shell.rs distinguishes them via `is_fatal()`.  Issue #28
+        // tracks replacing this with concurrent OS-level pipes, which will
+        // require explicit wait/reap handling for already-started children.
         execute_stage_capture(
             command, args, io, ctx, stdout_redirect, stderr_redirect, prev.as_deref(), &mut out_buf,
         )?;

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -231,7 +231,7 @@ fn test_pipeline_last_stage_nonzero_surfaces_error() {
         .script("echo ok | false")
         .run();
     assert!(
-        result.error().contains("exited with status") || result.error().contains("false"),
+        result.error().contains("exited with status"),
         "expected exit failure in stderr, got: {:?}",
         result.error()
     );
@@ -245,7 +245,7 @@ fn test_pipeline_all_succeed_no_error() {
         .run();
     result.assert_output_contains("hello");
     assert!(
-        result.error().is_empty() || !result.error().contains("exited with status"),
+        result.error().is_empty(),
         "no error expected for successful pipeline, got: {:?}",
         result.error()
     );

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -192,3 +192,61 @@ fn test_pipeline_builtin_receives_piped_stdin() {
         "upstream builtin output must be routed into the pipe, not leaked to terminal stdout"
     );
 }
+
+// --- Pipeline fail-fast / exit code propagation (issue #30) ---
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_aborts_on_first_stage_failure() {
+    // `false` exits 1; the pipeline must abort before `echo` runs.
+    let result = ShellTest::new()
+        .script("false | echo should_not_run")
+        .run();
+    assert!(
+        !result.output().contains("should_not_run"),
+        "pipeline must abort at the first failing stage, got: {:?}",
+        result.output()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_aborts_on_middle_stage_failure() {
+    // `echo a` succeeds, then `false` fails; `echo should_not_run` must not execute.
+    let result = ShellTest::new()
+        .script("echo a | false | echo should_not_run")
+        .run();
+    assert!(
+        !result.output().contains("should_not_run"),
+        "pipeline must abort at the failing middle stage, got: {:?}",
+        result.output()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_last_stage_nonzero_surfaces_error() {
+    // When the last stage fails, the error is reported to the user.
+    let result = ShellTest::new()
+        .script("echo ok | false")
+        .run();
+    assert!(
+        result.error().contains("exited with status") || result.error().contains("false"),
+        "expected exit failure in stderr, got: {:?}",
+        result.error()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_pipeline_all_succeed_no_error() {
+    let result = ShellTest::new()
+        .script("echo hello | cat")
+        .run();
+    result.assert_output_contains("hello");
+    assert!(
+        result.error().is_empty() || !result.error().contains("exited with status"),
+        "no error expected for successful pipeline, got: {:?}",
+        result.error()
+    );
+}


### PR DESCRIPTION
Pipeline fail-fast behavior was already correct (non-zero intermediate stage exits abort via `?` propagation), but the intent was implicit and untested. This PR makes it explicit and verified.

**Changes:**
- `src/error.rs`: Add `ShellError::as_exit_status()` — cleanly extracts the exit status from both bare `NonZeroExit` and the `InCommand`-wrapped variant, without pattern-matching through the wrapper at each call site. Needed by the upcoming `pass` builtin (issue to follow).
- `src/executor.rs`: Add a comment at the `?`-propagation point documenting that fail-fast is intentional and explaining how the REPL distinguishes non-zero exits from fatal errors.
- `tests/pipeline.rs`: Four new integration tests covering fail-fast at the first stage, fail-fast at a middle stage, non-zero last-stage error surfacing, and the all-succeed baseline.

`pipeline_statuses` tracking is deferred to the `pass`-builtin issue, where it earns its value by recording failures that `pass` normalizes to 0.

Closes #30