### PR TITLE
chore: switch coverage from tarpaulin to cargo-llvm-cov

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - name: install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --version 0.6.13 --locked
       - name: run coverage
         run: cargo llvm-cov --all-features --workspace --fail-under 80 --lcov --output-path lcov.info
       - name: upload to coveralls

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,15 +26,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - name: install tarpaulin
-        run: cargo install cargo-tarpaulin --version 0.31.5 --locked
+      - name: install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
       - name: run coverage
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-        run: |
-          if [ -n "$COVERALLS_REPO_TOKEN" ]; then
-            cargo tarpaulin --verbose --all-features --workspace --timeout 180 --coveralls "$COVERALLS_REPO_TOKEN" --fail-under 80
-          else
-            cargo tarpaulin --verbose --all-features --workspace --timeout 180 --fail-under 80
-          fi
+        run: cargo llvm-cov --all-features --workspace --fail-under 80 --lcov --output-path lcov.info
+      - name: upload to coveralls
+        if: ${{ secrets.COVERALLS_TOKEN != '' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          file: lcov.info
+          coveralls-token: ${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
`cargo-tarpaulin` uses ptrace to intercept syscalls, which is blocked by the seccomp sandbox in GitHub Actions when `--follow-exec` is used, and it has no visibility into child processes spawned by tests regardless. `cargo-llvm-cov` uses LLVM source-based instrumentation instead: each instrumented binary writes a `.profraw` file on exit, and when `ShellHarness` (PR #101) propagates `LLVM_PROFILE_FILE` to spawned `ferrish` subprocesses, those writes land in the same collection directory so `cargo llvm-cov` can merge them all before reporting.

This PR updates the CI workflow to install `cargo-llvm-cov` (requires `llvm-tools-preview` rustup component) and run it with `--fail-under 80`. Coverage output is written as lcov and uploaded to Coveralls via `coverallsapp/github-action` when `COVERALLS_TOKEN` is configured.

Closes #103