### PR TITLE
chore: migrate coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,10 +32,10 @@ jobs:
       - name: install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --version 0.6.13 --locked
       - name: run coverage
-        run: cargo llvm-cov --all-features --workspace --fail-under 80 --lcov --output-path lcov.info
-      - name: upload to coveralls
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
-        uses: coverallsapp/github-action@v2
+        run: cargo llvm-cov --all-features --workspace --fail-under 80 --codecov --output-path codecov.json
+      - name: upload to codecov
+        uses: codecov/codecov-action@v4
         with:
-          file: lcov.info
-          coveralls-token: ${{ secrets.COVERALLS_TOKEN }}
+          files: codecov.json
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/cdprice02/ferrish/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/cdprice02/ferrish/actions/workflows/build.yml)
 [![test](https://github.com/cdprice02/ferrish/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/cdprice02/ferrish/actions/workflows/test.yml)
 [![lint](https://github.com/cdprice02/ferrish/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/cdprice02/ferrish/actions/workflows/lint.yml)
-[![coverage](https://coveralls.io/repos/github/cdprice02/ferrish/badge.svg?branch=main)](https://coveralls.io/github/cdprice02/ferrish?branch=main)
+[![codecov](https://codecov.io/gh/cdprice02/ferrish/branch/main/graph/badge.svg)](https://codecov.io/gh/cdprice02/ferrish)
 <!--
 [![crates.io](https://img.shields.io/crates/v/ferrish.svg)](https://crates.io/crates/ferrish)
 [![docs.rs](https://docs.rs/ferrish/badge.svg)](https://docs.rs/ferrish)


### PR DESCRIPTION
Fixes the lint CI failure from PR #104 caused by `if: ${{ secrets.COVERALLS_TOKEN != '' }}` — GitHub Actions does not reliably support secrets in `if` expressions.

`cargo-llvm-cov` natively supports `--codecov` JSON output, and `codecov/codecov-action@v4` uploads it without needing a conditional. Setting `fail_ci_if_error: false` means CI passes even before `CODECOV_TOKEN` is configured in the repository secrets.

**Badge** updated in README.md from Coveralls to Codecov.

**Migrating historical data:** there is no migration path between Coveralls and Codecov — neither service provides a bulk-history import. Historical data will remain accessible at `coveralls.io/github/cdprice02/ferrish` as long as the Coveralls account is active, but coverage history in Codecov starts fresh from the first upload. For a project at this stage that is the right trade-off.

To activate Codecov: sign up at codecov.io, add the repo, and optionally set `CODECOV_TOKEN` as a repository secret (not required for public repos — the action uses GitHub OIDC by default).

Closes #105