### PR TITLE
fix: remove if-gate on Coveralls upload step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,6 @@ jobs:
       - name: run coverage
         run: cargo llvm-cov --all-features --workspace --fail-under 80 --lcov --output-path lcov.info
       - name: upload to coveralls
-        if: ${{ secrets.COVERALLS_TOKEN != '' }}
         uses: coverallsapp/github-action@v2
         with:
           file: lcov.info


### PR DESCRIPTION
The `if: ${{ secrets.COVERALLS_TOKEN != '' }}` condition on the Coveralls upload step caused the lint CI job to fail — GitHub Actions does not support the `secrets` context in `if` expressions.

The token is always configured, so the conditional is unnecessary. Dropping it entirely means the step runs unconditionally and fails naturally if the token is ever missing (which is acceptable).

No other changes — lcov output and `coverallsapp/github-action@v2` stay as-is.