### PR TITLE
feat: OS-level concurrent pipes with unified stage dispatch

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::env;
 
 /// Configurable shell settings.
+#[derive(Clone)]
 pub struct ShellConfig {
     /// The prompt string displayed before each input line.
     pub prompt: String,
@@ -23,6 +24,7 @@ impl Default for ShellConfig {
 }
 
 /// Runtime context shared across all shell operations.
+#[derive(Clone)]
 pub struct ShellCtx {
     /// The user's home directory, if known.
     pub home_dir: Option<PathBuf>,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,8 @@
+use std::io::{PipeReader, PipeWriter, Write};
 use std::path::PathBuf;
+use std::process::{Child, Stdio};
 use std::str::FromStr;
+use std::thread::{self, JoinHandle};
 
 use is_executable::IsExecutable;
 
@@ -7,7 +10,6 @@ use crate::{
     Arg, Command,
     arg::Args,
     command::builtin::{BuiltInCommand, BuiltInName},
-    command::executable::ExecutableCommand,
     ctx::ShellCtx,
     env::get_path_dirs,
     error::{ShellError, ShellResult},
@@ -75,226 +77,381 @@ fn open_redirect_file(
     }
 }
 
+/// Resolved stdout destination for one pipeline stage.
+enum StageOutput {
+    /// Intermediate stage: output feeds the next stage's stdin.
+    Pipe(PipeWriter),
+    /// Any stage with an explicit stdout redirect.
+    File(std::fs::File),
+    /// Last stage, no redirect: use the shell's output writer.
+    Terminal,
+}
+
+/// Resolved stderr destination for one pipeline stage.
+enum StageError {
+    /// Stage with an explicit stderr redirect.
+    File(std::fs::File),
+    /// No redirect: write to the shell's error writer (builtins) or inherit
+    /// the process stderr (executables).
+    Terminal,
+}
+
+/// Handle returned after launching one pipeline stage.
+enum StageHandle {
+    /// A spawned OS process.
+    Process(Child),
+    /// A builtin running in a background thread (intermediate stage).
+    Thread(JoinHandle<ShellResult<Option<ExitCode>>>),
+    /// A builtin that ran synchronously (last-stage Terminal output).
+    Done(ShellResult<Option<ExitCode>>),
+}
+
+/// Single dispatch for launching any pipeline stage — builtin or executable.
+///
+/// Builtins at intermediate positions (non-Terminal stdout) run in a thread
+/// with an isolated `ctx` clone so their side-effects (e.g. `cd`) don't
+/// propagate back — matching POSIX subshell semantics for pipeline stages.
+/// Builtins at the last stage (Terminal stdout) run synchronously.
+/// Executables always spawn a child process.
+#[allow(clippy::too_many_arguments)]
+fn launch_stage(
+    command: Command,
+    args: Args,
+    stdin: Option<PipeReader>,
+    stdout: StageOutput,
+    stderr: StageError,
+    shell_out: &mut dyn Write,
+    shell_err: &mut dyn Write,
+    ctx: &mut ShellCtx,
+) -> ShellResult<StageHandle> {
+    match command {
+        Command::BuiltIn(builtin) => {
+            drop(stdin); // builtins ignore piped stdin; the closed read end
+                         // sends SIGPIPE/EOF upstream, which is correct
+
+            // Last stage with no stdout redirect: run synchronously so we can
+            // write directly to the shell's `out`/`err` writers (which are not
+            // `Send` and cannot be moved into a thread).
+            if matches!(stdout, StageOutput::Terminal) {
+                let mut err_file: Option<std::fs::File> = match stderr {
+                    StageError::File(f) => Some(f),
+                    StageError::Terminal => None,
+                };
+                let eff_err: &mut dyn Write = match err_file.as_mut() {
+                    Some(f) => f,
+                    None => shell_err,
+                };
+                let result = execute_builtin(&builtin, args, shell_out, eff_err, ctx)
+                    .map_err(|e| ShellError::InCommand {
+                        command: Command::BuiltIn(builtin.clone()),
+                        source: Box::new(e),
+                    });
+                return Ok(StageHandle::Done(result));
+            }
+
+            let stdout_writer: Box<dyn Write + Send> = match stdout {
+                StageOutput::Pipe(pw) => Box::new(pw),
+                StageOutput::File(f) => Box::new(f),
+                StageOutput::Terminal => unreachable!(),
+            };
+            let stderr_writer: Box<dyn Write + Send> = match stderr {
+                StageError::File(f) => Box::new(f),
+                StageError::Terminal => Box::new(std::io::stderr()),
+            };
+
+            let mut ctx_clone = ctx.clone();
+            let handle = thread::spawn(move || {
+                let mut out = stdout_writer;
+                let mut err = stderr_writer;
+                execute_builtin(&builtin, args, &mut *out, &mut *err, &mut ctx_clone)
+                    .map_err(|e| ShellError::InCommand {
+                        command: Command::BuiltIn(builtin),
+                        source: Box::new(e),
+                    })
+            });
+            Ok(StageHandle::Thread(handle))
+        }
+
+        Command::Executable(executable) => {
+            let stdin_stdio = stdin.map_or(Stdio::inherit(), Stdio::from);
+            let stdout_stdio = match stdout {
+                StageOutput::Pipe(pw) => Stdio::from(pw),
+                StageOutput::File(f) => Stdio::from(f),
+                StageOutput::Terminal => Stdio::piped(),
+            };
+            let stderr_stdio = match stderr {
+                StageError::File(f) => Stdio::from(f),
+                StageError::Terminal => Stdio::piped(),
+            };
+
+            let args_strs: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+            let spawn_result = std::process::Command::new(executable.file_path())
+                .args(args_strs)
+                .current_dir(&ctx.cwd)
+                .stdin(stdin_stdio)
+                .stdout(stdout_stdio)
+                .stderr(stderr_stdio)
+                .spawn()
+                .map_err(ShellError::ExecutionFailed);
+
+            spawn_result
+                .map(StageHandle::Process)
+                .map_err(|e| ShellError::InCommand {
+                    command: Command::Executable(executable),
+                    source: Box::new(e),
+                })
+        }
+
+        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(&cmd).into_owned(),
+        }),
+    }
+}
+
+/// Spawn a thread that drains `pipe` into a `Vec<u8>`.
+fn spawn_drain_thread<R: std::io::Read + Send + 'static>(
+    mut pipe: R,
+) -> JoinHandle<std::io::Result<Vec<u8>>> {
+    thread::spawn(move || {
+        let mut buf = Vec::new();
+        std::io::copy(&mut pipe, &mut buf)?;
+        Ok(buf)
+    })
+}
+
+/// Wait for a child process, drain any piped stdout/stderr into `out`/`err`,
+/// and return the exit result.
+fn drain_and_wait(
+    mut child: Child,
+    stdout_drain: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    stderr_drain: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
+) -> ShellResult<Option<ExitCode>> {
+    let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+    if let Some(t) = stdout_drain {
+        out.write_all(&join_io_thread(t, "stdout")?)?;
+    }
+    if let Some(t) = stderr_drain {
+        err.write_all(&join_io_thread(t, "stderr")?)?;
+    }
+    if !status.success() {
+        return Err(ShellError::NonZeroExit(status));
+    }
+    Ok(None)
+}
+
+/// Collect the result of a single (non-last) pipeline stage.
+/// Intermediate process stderr is piped — drain it and discard (it already
+/// went to the child's own stderr fd chain; we don't re-route it here).
+fn wait_one(handle: StageHandle) -> ShellResult<Option<ExitCode>> {
+    match handle {
+        StageHandle::Done(r) => r,
+        StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
+            Err(ShellError::Io(std::io::Error::other(
+                "pipeline stage thread panicked",
+            )))
+        }),
+        StageHandle::Process(mut child) => {
+            // Drain and discard intermediate stderr so the child doesn't block
+            // writing to a full pipe buffer. We don't re-route it because
+            // intermediate stages' stderr goes directly to the terminal via
+            // the process hierarchy (the parent ferrish process's stderr fd).
+            // Actually: we piped it above, so we must drain it to avoid
+            // blocking the child. Write it through to the real stderr.
+            let stderr_drain = child.stderr.take().map(spawn_drain_thread);
+            let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+            if let Some(t) = stderr_drain {
+                // Write intermediate stage stderr to real process stderr
+                std::io::stderr().write_all(&join_io_thread(t, "stderr")?)?;
+            }
+            if status.success() {
+                Ok(None)
+            } else {
+                Err(ShellError::NonZeroExit(status))
+            }
+        }
+    }
+}
+
+/// Wait for all launched pipeline stages and collect their results.
+///
+/// Drain threads for the last `Process` stage are started *before* waiting
+/// on intermediate stages to prevent deadlock: intermediate processes write
+/// to OS pipes that the last process reads; if the last process's piped stdout
+/// buffer fills up before we drain it, the whole chain stalls.
+fn wait_pipeline(
+    handles: Vec<StageHandle>,
+    shell_out: &mut dyn Write,
+    shell_err: &mut dyn Write,
+) -> ShellResult<Option<ExitCode>> {
+    let mut handles = handles;
+    let last = handles.pop().expect("non-empty pipeline checked at call site");
+
+    // Pre-start drain threads for the last Process's stdout and stderr before
+    // waiting on intermediate stages.
+    let (last_process, last_stdout_drain, last_stderr_drain) = match last {
+        StageHandle::Process(mut c) => {
+            let stdout_drain = c.stdout.take().map(spawn_drain_thread);
+            let stderr_drain = c.stderr.take().map(spawn_drain_thread);
+            (Some(c), stdout_drain, stderr_drain)
+        }
+        other => {
+            handles.push(other);
+            (None, None, None)
+        }
+    };
+
+    let last_non_process = if last_process.is_none() {
+        handles.pop()
+    } else {
+        None
+    };
+
+    let mut first_error: Option<ShellError> = None;
+    let mut exit_request: Option<ExitCode> = None;
+
+    macro_rules! record {
+        ($result:expr) => {
+            match $result {
+                Ok(Some(code)) => exit_request = Some(code),
+                Ok(None) => {}
+                Err(e) if first_error.is_none() => first_error = Some(e),
+                Err(_) => {}
+            }
+        };
+    }
+
+    // Wait for all intermediate stages.
+    for handle in handles {
+        record!(wait_one(handle));
+    }
+
+    // Collect the last stage result.
+    if let Some(mut child) = last_process {
+        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+        if let Some(t) = last_stdout_drain {
+            shell_out.write_all(&join_io_thread(t, "stdout")?)?;
+        }
+        if let Some(t) = last_stderr_drain {
+            shell_err.write_all(&join_io_thread(t, "stderr")?)?;
+        }
+        if !status.success() && first_error.is_none() {
+            first_error = Some(ShellError::NonZeroExit(status));
+        }
+    } else if let Some(handle) = last_non_process {
+        record!(wait_one(handle));
+    }
+
+    if let Some(e) = first_error {
+        Err(e)
+    } else {
+        Ok(exit_request)
+    }
+}
+
 /// Dispatch and execute a parsed command, returning an optional exit code.
-///
-/// When `stdout_redirect` is `Some`, the command's standard output is written
-/// to the named file (overwriting or appending, per [`RedirectMode`]) instead
-/// of the shell's normal stdout.  When `stderr_redirect` is `Some`, the
-/// command's standard error is redirected likewise.  Any combination of
-/// redirects may be present independently.
-///
-/// Returns `Ok(Some(code))` when the command requests shell exit, `Ok(None)` otherwise.
 pub fn execute(
     command: Command,
     args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
     ctx: &mut ShellCtx,
     stdout_redirect: Option<StdoutRedirection>,
     stderr_redirect: Option<StderrRedirection>,
 ) -> ShellResult<Option<ExitCode>> {
-    let mut stdout_file: Option<std::fs::File> = stdout_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let mut stderr_file: Option<std::fs::File> = stderr_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let eff_out: &mut dyn std::io::Write = match stdout_file.as_mut() {
-        Some(f) => f,
-        None => out,
+    let stdout = if let Some(r) = stdout_redirect {
+        StageOutput::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
+    } else {
+        StageOutput::Terminal
     };
-    let eff_err: &mut dyn std::io::Write = match stderr_file.as_mut() {
-        Some(f) => f,
-        None => err,
+    let stderr = if let Some(r) = stderr_redirect {
+        StageError::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
+    } else {
+        StageError::Terminal
     };
-    execute_with_writers(command, args, eff_out, eff_err, ctx)
+
+    let handle = launch_stage(command, args, None, stdout, stderr, out, err, ctx)?;
+    match handle {
+        StageHandle::Done(r) => r,
+        StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
+            Err(ShellError::Io(std::io::Error::other(
+                "builtin thread panicked",
+            )))
+        }),
+        StageHandle::Process(mut child) => {
+            let stdout_drain = child.stdout.take().map(spawn_drain_thread);
+            let stderr_drain = child.stderr.take().map(spawn_drain_thread);
+            drain_and_wait(child, stdout_drain, stderr_drain, out, err)
+        }
+    }
 }
 
 /// Execute a [`Pipeline`] (one or more `|`-connected commands).
 ///
-/// A single-stage pipeline delegates to [`execute`] unchanged.  A multi-stage
-/// pipeline runs each stage serially: the stdout of stage *i* is buffered then
-/// fed as stdin to stage *i+1*.  For executable stages the data is written into
-/// the child's stdin pipe; built-in stages do not currently consume piped stdin
-/// data.  The last stage's stdout is written to `out` (or to a file if a
-/// per-stage redirect is present).
-///
-/// Stdout buffering is intentional for this implementation — issue #28 will
-/// replace it with OS-level streaming pipes between concurrent processes.
+/// A single-stage pipeline delegates to [`execute`] unchanged. A multi-stage
+/// pipeline creates N-1 OS-level pipes, launches all N stages concurrently
+/// (executables as child processes, builtins in threads), then waits for all.
+/// Data flows directly between processes via kernel pipe buffers — no
+/// in-memory buffering between stages.
 ///
 /// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
 pub fn execute_pipeline(
     pipeline: Pipeline,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
-    // Fast path: no pipe operators.
     if pipeline.len() == 1 {
         let (cmd, args, stdout_redir, stderr_redir) = pipeline.into_iter().next().unwrap();
         return execute(cmd, args, out, err, ctx, stdout_redir, stderr_redir);
     }
 
-    // Multi-stage: carry the previous stage's captured stdout forward.
-    let mut stdin_buf: Option<Vec<u8>> = None;
-    let last_idx = pipeline.len() - 1;
+    let stages: Vec<_> = pipeline.into_iter().collect();
+    let n = stages.len();
 
-    for (i, (command, args, stdout_redirect, stderr_redirect)) in pipeline.into_iter().enumerate() {
-        let is_last = i == last_idx;
+    // Create N-1 inter-stage pipes.  Both ends are consumed by launch_stage
+    // (moved into Stdio::from or a thread closure), so the parent holds no
+    // open pipe ends after the launch loop — no manual cleanup needed.
+    let pipe_pairs: std::io::Result<Vec<_>> = (0..n - 1).map(|_| std::io::pipe()).collect();
+    let (mut readers, mut writers): (Vec<_>, Vec<_>) = pipe_pairs
+        .map_err(ShellError::Io)?
+        .into_iter()
+        .map(|(r, w)| (Some(r), Some(w)))
+        .unzip();
 
-        if is_last {
-            return if let Some(buf) = stdin_buf.take() {
-                execute_stage_with_stdin(
-                    command, args, out, err, ctx, stdout_redirect, stderr_redirect, &buf,
-                )
-            } else {
-                execute(command, args, out, err, ctx, stdout_redirect, stderr_redirect)
-            };
-        }
+    let mut handles = Vec::with_capacity(n);
 
-        let mut out_buf: Vec<u8> = Vec::new();
-        let prev = stdin_buf.take();
-        // Fail-fast: any non-zero exit from an intermediate stage aborts the pipeline.
-        // Issue #28 tracks replacing this with concurrent OS-level pipes.
-        execute_stage_capture(
-            command, args, err, ctx, stdout_redirect, stderr_redirect, prev.as_deref(), &mut out_buf,
-        )?;
-        stdin_buf = Some(out_buf);
+    for (i, (command, args, stdout_redirect, stderr_redirect)) in
+        stages.into_iter().enumerate()
+    {
+        let stdin: Option<PipeReader> = if i == 0 { None } else { readers[i - 1].take() };
+
+        let stdout = if let Some(r) = stdout_redirect {
+            StageOutput::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
+        } else if i < n - 1 {
+            StageOutput::Pipe(writers[i].take().unwrap())
+        } else {
+            StageOutput::Terminal
+        };
+
+        let stderr = if let Some(r) = stderr_redirect {
+            StageError::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
+        } else {
+            StageError::Terminal
+        };
+
+        handles.push(launch_stage(command, args, stdin, stdout, stderr, out, err, ctx)?);
     }
 
-    Ok(None)
-}
-
-/// Run one intermediate pipeline stage, feeding `stdin_data` as the command's
-/// stdin.  If `stdout_redirect` is `Some`, stdout goes to that file (POSIX
-/// semantics); otherwise it is captured into `out_buf` for the next stage.
-/// Stderr honours `stderr_redirect` or falls back to the provided `err` writer.
-#[allow(clippy::too_many_arguments)]
-fn execute_stage_capture(
-    command: Command,
-    args: Args,
-    err: &mut dyn std::io::Write,
-    ctx: &mut ShellCtx,
-    stdout_redirect: Option<StdoutRedirection>,
-    stderr_redirect: Option<StderrRedirection>,
-    stdin_data: Option<&[u8]>,
-    out_buf: &mut Vec<u8>,
-) -> ShellResult<Option<ExitCode>> {
-    let mut stdout_file: Option<std::fs::File> = stdout_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let mut stderr_file: Option<std::fs::File> = stderr_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let out_writer: &mut dyn std::io::Write = match stdout_file.as_mut() {
-        Some(f) => f,
-        None => out_buf,
-    };
-    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
-        Some(f) => f,
-        None => err,
-    };
-
-    execute_stage_inner(command, args, out_writer, err_writer, ctx, stdin_data)
-}
-
-/// Run the last pipeline stage, feeding `stdin_data` and honouring redirects.
-#[allow(clippy::too_many_arguments)]
-fn execute_stage_with_stdin(
-    command: Command,
-    args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
-    ctx: &mut ShellCtx,
-    stdout_redirect: Option<StdoutRedirection>,
-    stderr_redirect: Option<StderrRedirection>,
-    stdin_data: &[u8],
-) -> ShellResult<Option<ExitCode>> {
-    let mut stdout_file: Option<std::fs::File> = stdout_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let mut stderr_file: Option<std::fs::File> = stderr_redirect
-        .as_ref()
-        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
-        .transpose()?;
-
-    let out_writer: &mut dyn std::io::Write = match stdout_file.as_mut() {
-        Some(f) => f,
-        None => out,
-    };
-    let err_writer: &mut dyn std::io::Write = match stderr_file.as_mut() {
-        Some(f) => f,
-        None => err,
-    };
-
-    execute_stage_inner(command, args, out_writer, err_writer, ctx, Some(stdin_data))
-}
-
-/// Core dispatch for a pipeline stage: routes to builtin or executable, feeding
-/// `stdin_data` (if any) as the command's standard input.
-fn execute_stage_inner(
-    command: Command,
-    args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
-    ctx: &mut ShellCtx,
-    stdin_data: Option<&[u8]>,
-) -> ShellResult<Option<ExitCode>> {
-    let result = match &command {
-        Command::BuiltIn(builtin) => {
-            // Builtins don't consume stdin from a pipe — they ignore it.
-            execute_builtin(builtin, args, out, err, ctx)
-        }
-        Command::Executable(executable) => {
-            execute_executable(executable, args, out, err, ctx, stdin_data)
-        }
-        Command::Unrecognized(cmd) => {
-            return Err(ShellError::CommandNotFound {
-                name: String::from_utf8_lossy(cmd).into_owned(),
-            })
-        }
-    };
-    result.map_err(|e| ShellError::InCommand { command, source: Box::new(e) })
-}
-
-/// Core dispatch: all output goes to the provided `out` and `err` writers.
-///
-/// This separation makes it possible to redirect stdout to a file while keeping
-/// stderr on the terminal without changing the `ShellIo` abstraction.
-fn execute_with_writers(
-    command: Command,
-    args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
-    ctx: &mut ShellCtx,
-) -> ShellResult<Option<ExitCode>> {
-    let result = match &command {
-        Command::BuiltIn(builtin) => execute_builtin(builtin, args, out, err, ctx),
-        Command::Executable(executable) => execute_executable(executable, args, out, err, ctx, None),
-        Command::Unrecognized(cmd) => {
-            return Err(ShellError::CommandNotFound {
-                name: String::from_utf8_lossy(cmd).into_owned(),
-            })
-        }
-    };
-    result.map_err(|e| ShellError::InCommand { command, source: Box::new(e) })
+    wait_pipeline(handles, out, err)
 }
 
 fn execute_builtin(
     builtin: &BuiltInCommand,
     args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     match builtin.name() {
@@ -339,7 +496,7 @@ fn execute_cd(args: Args, ctx: &mut ShellCtx) -> ShellResult<()> {
     Ok(())
 }
 
-fn execute_echo(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
+fn execute_echo(args: Args, out: &mut dyn Write) -> ShellResult<()> {
     writeln!(
         out,
         "{}",
@@ -352,7 +509,7 @@ fn execute_echo(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
     Ok(())
 }
 
-fn execute_type(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
+fn execute_type(args: Args, out: &mut dyn Write) -> ShellResult<()> {
     if args.is_empty() {
         return Err(ShellError::MissingOperand);
     }
@@ -379,102 +536,18 @@ fn execute_type(args: Args, out: &mut dyn std::io::Write) -> ShellResult<()> {
 
 fn execute_pwd(
     _args: Args,
-    out: &mut dyn std::io::Write,
+    out: &mut dyn Write,
     ctx: &ShellCtx,
 ) -> ShellResult<()> {
     writeln!(out, "{}", ctx.cwd.display())?;
     Ok(())
 }
 
-fn execute_executable(
-    executable: &ExecutableCommand,
-    args: Args,
-    out: &mut dyn std::io::Write,
-    err: &mut dyn std::io::Write,
-    ctx: &ShellCtx,
-    stdin_data: Option<&[u8]>,
-) -> ShellResult<Option<ExitCode>> {
-    use std::io::Write as _;
-    use std::process::Stdio;
-    use std::thread;
-
-    let args = args.iter().map(|a| a.to_string()).collect::<Vec<_>>();
-    let mut child = std::process::Command::new(executable.file_path())
-        .args(args)
-        .current_dir(&ctx.cwd)
-        .stdin(if stdin_data.is_some() { Stdio::piped() } else { Stdio::inherit() })
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(ShellError::ExecutionFailed)?;
-
-    // Spawn a stdin writer before draining stdout/stderr to avoid deadlock:
-    // the child may fill its stdout buffer before reading all stdin, so we
-    // must drain both concurrently.  `ChildStdin`/`ChildStdout`/`ChildStderr`
-    // are `Send`, so they can be moved into threads safely.
-    let stdin_thread = stdin_data
-        .zip(child.stdin.take())
-        .map(|(data, mut child_stdin)| {
-            let data = data.to_vec();
-            thread::spawn(move || -> std::io::Result<()> {
-                // BrokenPipe means the child exited before reading all stdin — treat
-                // as success so a fast downstream command (e.g. `head -1`) doesn't
-                // surface a spurious I/O error.
-                if let Err(e) = child_stdin.write_all(&data)
-                    && e.kind() != std::io::ErrorKind::BrokenPipe
-                {
-                    return Err(e);
-                }
-                Ok(()) // drop closes the pipe
-            })
-        });
-
-    let stdout_thread = child.stdout.take().map(|mut pipe| {
-        thread::spawn(move || -> std::io::Result<Vec<u8>> {
-            let mut buf = Vec::new();
-            std::io::copy(&mut pipe, &mut buf)?;
-            Ok(buf)
-        })
-    });
-    let stderr_thread = child.stderr.take().map(|mut pipe| {
-        thread::spawn(move || -> std::io::Result<Vec<u8>> {
-            let mut buf = Vec::new();
-            std::io::copy(&mut pipe, &mut buf)?;
-            Ok(buf)
-        })
-    });
-
-    // Always wait on the child so it is reaped even when I/O copy fails.
-    let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-
-    if let Some(handle) = stdin_thread {
-        handle
-            .join()
-            .unwrap_or_else(|_| Err(std::io::Error::other("stdin thread panicked")))
-            .map_err(ShellError::Io)?;
-    }
-
-    if let Some(handle) = stdout_thread {
-        let bytes = join_io_thread(handle, "stdout")?;
-        out.write_all(&bytes)?;
-    }
-    if let Some(handle) = stderr_thread {
-        let bytes = join_io_thread(handle, "stderr")?;
-        err.write_all(&bytes)?;
-    }
-
-    if !status.success() {
-        return Err(ShellError::NonZeroExit(status));
-    }
-
-    Ok(None)
-}
-
 /// Join an I/O drain thread and convert both join-failure and I/O errors into
 /// a non-fatal [`ShellError::Io`].  `stream` names the pipe ("stdout"/"stderr")
 /// and is included in the panic-message for easier debugging.
 fn join_io_thread(
-    handle: std::thread::JoinHandle<std::io::Result<Vec<u8>>>,
+    handle: JoinHandle<std::io::Result<Vec<u8>>>,
     stream: &str,
 ) -> ShellResult<Vec<u8>> {
     handle

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -41,7 +41,6 @@ fn resolve_command_type(name: &[u8]) -> CommandKind {
         if candidate.is_executable() {
             return CommandKind::Executable(candidate);
         }
-        // On Windows executables typically carry a .exe extension
         #[cfg(windows)]
         {
             let candidate_exe = dir.join(format!("{name_str}.exe"));
@@ -66,9 +65,7 @@ fn open_redirect_file(
         cwd.join(target)
     };
     match mode {
-        RedirectMode::Overwrite => {
-            std::fs::File::create(&target_path).map_err(ShellError::Io)
-        }
+        RedirectMode::Overwrite => std::fs::File::create(&target_path).map_err(ShellError::Io),
         RedirectMode::Append => std::fs::OpenOptions::new()
             .append(true)
             .create(true)
@@ -79,97 +76,67 @@ fn open_redirect_file(
 
 /// Resolved stdout destination for one pipeline stage.
 enum StageOutput {
-    /// Intermediate stage: output feeds the next stage's stdin.
+    /// Inter-stage stdout: write end feeds the next stage's stdin.
     Pipe(PipeWriter),
-    /// Any stage with an explicit stdout redirect.
+    /// Explicit stdout redirect: write directly to this file.
     File(std::fs::File),
-    /// Last stage, no redirect: use the shell's output writer.
-    Terminal,
+    /// No redirect (last stage or single command): inherit the process stdout fd.
+    Inherit,
 }
 
 /// Resolved stderr destination for one pipeline stage.
 enum StageError {
-    /// Stage with an explicit stderr redirect.
+    /// Explicit stderr redirect: write directly to this file.
     File(std::fs::File),
-    /// No redirect: write to the shell's error writer (builtins) or inherit
-    /// the process stderr (executables).
-    Terminal,
+    /// No redirect: inherit the process stderr fd. Applies to all stages.
+    Inherit,
 }
 
 /// Handle returned after launching one pipeline stage.
 enum StageHandle {
+    /// A builtin running in a background thread.
+    Thread(JoinHandle<ShellResult<Option<ExitCode>>>),
     /// A spawned OS process.
     Process(Child),
-    /// A builtin running in a background thread (intermediate stage).
-    Thread(JoinHandle<ShellResult<Option<ExitCode>>>),
-    /// A builtin that ran synchronously (last-stage Terminal output).
-    Done(ShellResult<Option<ExitCode>>),
 }
+
 
 /// Single dispatch for launching any pipeline stage — builtin or executable.
 ///
-/// Builtins at intermediate positions (non-Terminal stdout) run in a thread
-/// with an isolated `ctx` clone so their side-effects (e.g. `cd`) don't
-/// propagate back — matching POSIX subshell semantics for pipeline stages.
-/// Builtins at the last stage (Terminal stdout) run synchronously.
-/// Executables always spawn a child process.
-#[allow(clippy::too_many_arguments)]
+/// Both kinds receive resolved IO destinations via [`StageOutput`] and
+/// [`StageError`]. Builtins always run in a thread with a cloned context
+/// (POSIX subshell semantics — side-effects like `cd` don't propagate back).
+/// Executables spawn a child process. The caller waits for the returned
+/// [`StageHandle`]; output flows directly through inherited fds or pipe ends
+/// with no intermediate buffering.
 fn launch_stage(
     command: Command,
     args: Args,
     stdin: Option<PipeReader>,
     stdout: StageOutput,
     stderr: StageError,
-    shell_out: &mut dyn Write,
-    shell_err: &mut dyn Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<StageHandle> {
     match command {
         Command::BuiltIn(builtin) => {
-            drop(stdin); // builtins ignore piped stdin; the closed read end
-                         // sends SIGPIPE/EOF upstream, which is correct
-
-            // Last stage with no stdout redirect: run synchronously so we can
-            // write directly to the shell's `out`/`err` writers (which are not
-            // `Send` and cannot be moved into a thread).
-            if matches!(stdout, StageOutput::Terminal) {
-                let mut err_file: Option<std::fs::File> = match stderr {
-                    StageError::File(f) => Some(f),
-                    StageError::Terminal => None,
-                };
-                let eff_err: &mut dyn Write = match err_file.as_mut() {
-                    Some(f) => f,
-                    None => shell_err,
-                };
-                let result = execute_builtin(&builtin, args, shell_out, eff_err, ctx)
-                    .map_err(|e| ShellError::InCommand {
-                        command: Command::BuiltIn(builtin.clone()),
-                        source: Box::new(e),
-                    });
-                return Ok(StageHandle::Done(result));
-            }
-
-            let stdout_writer: Box<dyn Write + Send> = match stdout {
+            let mut out_w: Box<dyn Write + Send> = match stdout {
                 StageOutput::Pipe(pw) => Box::new(pw),
                 StageOutput::File(f) => Box::new(f),
-                StageOutput::Terminal => unreachable!(),
+                StageOutput::Inherit => Box::new(std::io::stdout()),
             };
-            let stderr_writer: Box<dyn Write + Send> = match stderr {
+            let mut err_w: Box<dyn Write + Send> = match stderr {
                 StageError::File(f) => Box::new(f),
-                StageError::Terminal => Box::new(std::io::stderr()),
+                StageError::Inherit => Box::new(std::io::stderr()),
             };
-
             let mut ctx_clone = ctx.clone();
-            let handle = thread::spawn(move || {
-                let mut out = stdout_writer;
-                let mut err = stderr_writer;
-                execute_builtin(&builtin, args, &mut *out, &mut *err, &mut ctx_clone)
+            let h = thread::spawn(move || {
+                execute_builtin(&builtin, args, stdin, &mut *out_w, &mut *err_w, &mut ctx_clone)
                     .map_err(|e| ShellError::InCommand {
                         command: Command::BuiltIn(builtin),
                         source: Box::new(e),
                     })
             });
-            Ok(StageHandle::Thread(handle))
+            Ok(StageHandle::Thread(h))
         }
 
         Command::Executable(executable) => {
@@ -177,28 +144,24 @@ fn launch_stage(
             let stdout_stdio = match stdout {
                 StageOutput::Pipe(pw) => Stdio::from(pw),
                 StageOutput::File(f) => Stdio::from(f),
-                StageOutput::Terminal => Stdio::piped(),
+                StageOutput::Inherit => Stdio::inherit(),
             };
             let stderr_stdio = match stderr {
                 StageError::File(f) => Stdio::from(f),
-                StageError::Terminal => Stdio::piped(),
+                StageError::Inherit => Stdio::inherit(),
             };
-
             let args_strs: Vec<String> = args.iter().map(|a| a.to_string()).collect();
-            let spawn_result = std::process::Command::new(executable.file_path())
+            std::process::Command::new(executable.file_path())
                 .args(args_strs)
                 .current_dir(&ctx.cwd)
                 .stdin(stdin_stdio)
                 .stdout(stdout_stdio)
                 .stderr(stderr_stdio)
                 .spawn()
-                .map_err(ShellError::ExecutionFailed);
-
-            spawn_result
                 .map(StageHandle::Process)
                 .map_err(|e| ShellError::InCommand {
                     command: Command::Executable(executable),
-                    source: Box::new(e),
+                    source: Box::new(ShellError::ExecutionFailed(e)),
                 })
         }
 
@@ -208,211 +171,80 @@ fn launch_stage(
     }
 }
 
-/// Spawn a thread that drains `pipe` into a `Vec<u8>`.
-fn spawn_drain_thread<R: std::io::Read + Send + 'static>(
-    mut pipe: R,
-) -> JoinHandle<std::io::Result<Vec<u8>>> {
-    thread::spawn(move || {
-        let mut buf = Vec::new();
-        std::io::copy(&mut pipe, &mut buf)?;
-        Ok(buf)
-    })
-}
-
-/// Wait for a child process, drain any piped stdout/stderr into `out`/`err`,
-/// and return the exit result.
-fn drain_and_wait(
-    mut child: Child,
-    stdout_drain: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
-    stderr_drain: Option<JoinHandle<std::io::Result<Vec<u8>>>>,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
-) -> ShellResult<Option<ExitCode>> {
-    let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-    if let Some(t) = stdout_drain {
-        out.write_all(&join_io_thread(t, "stdout")?)?;
-    }
-    if let Some(t) = stderr_drain {
-        err.write_all(&join_io_thread(t, "stderr")?)?;
-    }
-    if !status.success() {
-        return Err(ShellError::NonZeroExit(status));
-    }
-    Ok(None)
-}
-
-/// Collect the result of a single (non-last) pipeline stage.
-/// Intermediate process stderr is piped — drain it and discard (it already
-/// went to the child's own stderr fd chain; we don't re-route it here).
-fn wait_one(handle: StageHandle) -> ShellResult<Option<ExitCode>> {
-    match handle {
-        StageHandle::Done(r) => r,
-        StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
-            Err(ShellError::Io(std::io::Error::other(
-                "pipeline stage thread panicked",
-            )))
-        }),
-        StageHandle::Process(mut child) => {
-            // Drain and discard intermediate stderr so the child doesn't block
-            // writing to a full pipe buffer. We don't re-route it because
-            // intermediate stages' stderr goes directly to the terminal via
-            // the process hierarchy (the parent ferrish process's stderr fd).
-            // Actually: we piped it above, so we must drain it to avoid
-            // blocking the child. Write it through to the real stderr.
-            let stderr_drain = child.stderr.take().map(spawn_drain_thread);
-            let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-            if let Some(t) = stderr_drain {
-                // Write intermediate stage stderr to real process stderr
-                std::io::stderr().write_all(&join_io_thread(t, "stderr")?)?;
-            }
-            if status.success() {
-                Ok(None)
-            } else {
-                Err(ShellError::NonZeroExit(status))
-            }
-        }
-    }
-}
-
-/// Wait for all launched pipeline stages and collect their results.
+/// Dispatch and execute a single parsed command with optional redirects.
 ///
-/// Drain threads for the last `Process` stage are started *before* waiting
-/// on intermediate stages to prevent deadlock: intermediate processes write
-/// to OS pipes that the last process reads; if the last process's piped stdout
-/// buffer fills up before we drain it, the whole chain stalls.
-fn wait_pipeline(
-    handles: Vec<StageHandle>,
-    shell_out: &mut dyn Write,
-    shell_err: &mut dyn Write,
-) -> ShellResult<Option<ExitCode>> {
-    let mut handles = handles;
-    let last = handles.pop().expect("non-empty pipeline checked at call site");
-
-    // Pre-start drain threads for the last Process's stdout and stderr before
-    // waiting on intermediate stages.
-    let (last_process, last_stdout_drain, last_stderr_drain) = match last {
-        StageHandle::Process(mut c) => {
-            let stdout_drain = c.stdout.take().map(spawn_drain_thread);
-            let stderr_drain = c.stderr.take().map(spawn_drain_thread);
-            (Some(c), stdout_drain, stderr_drain)
-        }
-        other => {
-            handles.push(other);
-            (None, None, None)
-        }
-    };
-
-    let last_non_process = if last_process.is_none() {
-        handles.pop()
-    } else {
-        None
-    };
-
-    let mut first_error: Option<ShellError> = None;
-    let mut exit_request: Option<ExitCode> = None;
-
-    macro_rules! record {
-        ($result:expr) => {
-            match $result {
-                Ok(Some(code)) => exit_request = Some(code),
-                Ok(None) => {}
-                Err(e) if first_error.is_none() => first_error = Some(e),
-                Err(_) => {}
-            }
-        };
-    }
-
-    // Wait for all intermediate stages.
-    for handle in handles {
-        record!(wait_one(handle));
-    }
-
-    // Collect the last stage result.
-    if let Some(mut child) = last_process {
-        let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-        if let Some(t) = last_stdout_drain {
-            shell_out.write_all(&join_io_thread(t, "stdout")?)?;
-        }
-        if let Some(t) = last_stderr_drain {
-            shell_err.write_all(&join_io_thread(t, "stderr")?)?;
-        }
-        if !status.success() && first_error.is_none() {
-            first_error = Some(ShellError::NonZeroExit(status));
-        }
-    } else if let Some(handle) = last_non_process {
-        record!(wait_one(handle));
-    }
-
-    if let Some(e) = first_error {
-        Err(e)
-    } else {
-        Ok(exit_request)
-    }
-}
-
-/// Dispatch and execute a parsed command, returning an optional exit code.
+/// Builtins run synchronously in the caller's `ctx` so state-mutating commands
+/// like `cd` propagate back to the shell — matching POSIX semantics for
+/// commands that are not part of a multi-command pipeline.
 pub fn execute(
     command: Command,
     args: Args,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
     ctx: &mut ShellCtx,
     stdout_redirect: Option<StdoutRedirection>,
     stderr_redirect: Option<StderrRedirection>,
 ) -> ShellResult<Option<ExitCode>> {
-    let stdout = if let Some(r) = stdout_redirect {
-        StageOutput::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
-    } else {
-        StageOutput::Terminal
-    };
-    let stderr = if let Some(r) = stderr_redirect {
-        StageError::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
-    } else {
-        StageError::Terminal
-    };
+    let mut out_file: Option<std::fs::File> = stdout_redirect
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
+    let mut err_file: Option<std::fs::File> = stderr_redirect
+        .map(|r| open_redirect_file(&r.mode, &r.target, &ctx.cwd))
+        .transpose()?;
 
-    let handle = launch_stage(command, args, None, stdout, stderr, out, err, ctx)?;
-    match handle {
-        StageHandle::Done(r) => r,
-        StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
-            Err(ShellError::Io(std::io::Error::other(
-                "builtin thread panicked",
-            )))
-        }),
-        StageHandle::Process(mut child) => {
-            let stdout_drain = child.stdout.take().map(spawn_drain_thread);
-            let stderr_drain = child.stderr.take().map(spawn_drain_thread);
-            drain_and_wait(child, stdout_drain, stderr_drain, out, err)
+    match command {
+        Command::BuiltIn(builtin) => {
+            let mut stdout_default = std::io::stdout();
+            let mut stderr_default = std::io::stderr();
+            let out: &mut dyn Write = out_file.as_mut().map_or(&mut stdout_default as _, |f| f);
+            let err: &mut dyn Write = err_file.as_mut().map_or(&mut stderr_default as _, |f| f);
+            execute_builtin(&builtin, args, None, out, err, ctx).map_err(|e| {
+                ShellError::InCommand { command: Command::BuiltIn(builtin), source: Box::new(e) }
+            })
         }
+        Command::Executable(executable) => {
+            let stdout_stdio = out_file.map_or(Stdio::inherit(), Stdio::from);
+            let stderr_stdio = err_file.map_or(Stdio::inherit(), Stdio::from);
+            let args_strs: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+            let mut child = std::process::Command::new(executable.file_path())
+                .args(args_strs)
+                .current_dir(&ctx.cwd)
+                .stdin(Stdio::inherit())
+                .stdout(stdout_stdio)
+                .stderr(stderr_stdio)
+                .spawn()
+                .map_err(|e| ShellError::InCommand {
+                    command: Command::Executable(executable),
+                    source: Box::new(ShellError::ExecutionFailed(e)),
+                })?;
+            let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+            if status.success() { Ok(None) } else { Err(ShellError::NonZeroExit(status)) }
+        }
+        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(&cmd).into_owned(),
+        }),
     }
 }
 
 /// Execute a [`Pipeline`] (one or more `|`-connected commands).
 ///
-/// A single-stage pipeline delegates to [`execute`] unchanged. A multi-stage
-/// pipeline creates N-1 OS-level pipes, launches all N stages concurrently
-/// (executables as child processes, builtins in threads), then waits for all.
-/// Data flows directly between processes via kernel pipe buffers — no
-/// in-memory buffering between stages.
+/// A single-stage pipeline delegates to [`execute`]. A multi-stage pipeline
+/// creates N-1 OS-level inter-stage pipes, launches all N stages concurrently,
+/// and waits for all. Data flows between stages via kernel pipe buffers with no
+/// in-process buffering; output of the last stage goes to the inherited process
+/// stdout and stderr fds.
 ///
 /// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
 pub fn execute_pipeline(
     pipeline: Pipeline,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
     if pipeline.len() == 1 {
         let (cmd, args, stdout_redir, stderr_redir) = pipeline.into_iter().next().unwrap();
-        return execute(cmd, args, out, err, ctx, stdout_redir, stderr_redir);
+        return execute(cmd, args, ctx, stdout_redir, stderr_redir);
     }
 
     let stages: Vec<_> = pipeline.into_iter().collect();
     let n = stages.len();
 
-    // Create N-1 inter-stage pipes.  Both ends are consumed by launch_stage
-    // (moved into Stdio::from or a thread closure), so the parent holds no
-    // open pipe ends after the launch loop — no manual cleanup needed.
     let pipe_pairs: std::io::Result<Vec<_>> = (0..n - 1).map(|_| std::io::pipe()).collect();
     let (mut readers, mut writers): (Vec<_>, Vec<_>) = pipe_pairs
         .map_err(ShellError::Io)?
@@ -432,24 +264,49 @@ pub fn execute_pipeline(
         } else if i < n - 1 {
             StageOutput::Pipe(writers[i].take().unwrap())
         } else {
-            StageOutput::Terminal
+            StageOutput::Inherit
         };
 
-        let stderr = if let Some(r) = stderr_redirect {
-            StageError::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
-        } else {
-            StageError::Terminal
+        let stderr = match stderr_redirect {
+            Some(r) => StageError::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?),
+            None => StageError::Inherit,
         };
 
-        handles.push(launch_stage(command, args, stdin, stdout, stderr, out, err, ctx)?);
+        handles.push(launch_stage(command, args, stdin, stdout, stderr, ctx)?);
     }
 
-    wait_pipeline(handles, out, err)
+    let mut first_error: Option<ShellError> = None;
+    let mut exit_request: Option<ExitCode> = None;
+
+    for handle in handles {
+        let result = match handle {
+            StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
+                Err(ShellError::Io(std::io::Error::other("pipeline stage thread panicked")))
+            }),
+            StageHandle::Process(mut child) => {
+                let status = child.wait().map_err(ShellError::ExecutionFailed)?;
+                if status.success() { Ok(None) } else { Err(ShellError::NonZeroExit(status)) }
+            }
+        };
+        match result {
+            Ok(Some(code)) => exit_request = Some(code),
+            Ok(None) => {}
+            Err(e) if first_error.is_none() => first_error = Some(e),
+            Err(_) => {}
+        }
+    }
+
+    if let Some(e) = first_error {
+        Err(e)
+    } else {
+        Ok(exit_request)
+    }
 }
 
 fn execute_builtin(
     builtin: &BuiltInCommand,
     args: Args,
+    _stdin: Option<PipeReader>,
     out: &mut dyn Write,
     err: &mut dyn Write,
     ctx: &mut ShellCtx,
@@ -505,7 +362,6 @@ fn execute_echo(args: Args, out: &mut dyn Write) -> ShellResult<()> {
             .collect::<Vec<_>>()
             .join(" ")
     )?;
-
     Ok(())
 }
 
@@ -522,55 +378,18 @@ fn execute_type(args: Args, out: &mut dyn Write) -> ShellResult<()> {
             writeln!(out, "{} is a shell builtin", builtin_name)?
         }
         CommandKind::Executable(path) => {
-            let display_name = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("");
+            let display_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
             writeln!(out, "{} is {}", display_name, path.display())?
         }
-        CommandKind::NotFound => return Err(ShellError::CommandNotFound { name: arg.to_string() }),
+        CommandKind::NotFound => {
+            return Err(ShellError::CommandNotFound { name: arg.to_string() })
+        }
     }
 
     Ok(())
 }
 
-fn execute_pwd(
-    _args: Args,
-    out: &mut dyn Write,
-    ctx: &ShellCtx,
-) -> ShellResult<()> {
+fn execute_pwd(_args: Args, out: &mut dyn Write, ctx: &ShellCtx) -> ShellResult<()> {
     writeln!(out, "{}", ctx.cwd.display())?;
     Ok(())
-}
-
-/// Join an I/O drain thread and convert both join-failure and I/O errors into
-/// a non-fatal [`ShellError::Io`].  `stream` names the pipe ("stdout"/"stderr")
-/// and is included in the panic-message for easier debugging.
-fn join_io_thread(
-    handle: JoinHandle<std::io::Result<Vec<u8>>>,
-    stream: &str,
-) -> ShellResult<Vec<u8>> {
-    handle
-        .join()
-        .unwrap_or_else(|_| {
-            Err(std::io::Error::other(format!(
-                "{stream} I/O thread panicked"
-            )))
-        })
-        .map_err(ShellError::Io)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn join_io_thread_panic_becomes_non_fatal_io_error() {
-        let handle = std::thread::spawn(|| -> std::io::Result<Vec<u8>> { panic!("simulated OOM") });
-        let result = join_io_thread(handle, "stdout");
-        let err = result.expect_err("expected Err from panicking thread");
-        assert!(!err.is_fatal());
-        assert!(matches!(err, ShellError::Io(_)));
-        assert!(err.to_string().contains("stdout"));
-    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -95,9 +95,9 @@ enum StageError {
 /// Handle returned after launching one pipeline stage.
 enum StageHandle {
     /// A builtin running in a background thread.
-    Thread(JoinHandle<ShellResult<Option<ExitCode>>>),
+    Thread(JoinHandle<ShellResult<Option<ExitCode>>>, Command),
     /// A spawned OS process.
-    Process(Child),
+    Process(Child, Command),
 }
 
 
@@ -119,6 +119,7 @@ fn launch_stage(
 ) -> ShellResult<StageHandle> {
     match command {
         Command::BuiltIn(builtin) => {
+            let cmd_for_handle = Command::BuiltIn(builtin.clone());
             let mut out_w: Box<dyn Write + Send> = match stdout {
                 StageOutput::Pipe(pw) => Box::new(pw),
                 StageOutput::File(f) => Box::new(f),
@@ -136,7 +137,7 @@ fn launch_stage(
                         source: Box::new(e),
                     })
             });
-            Ok(StageHandle::Thread(h))
+            Ok(StageHandle::Thread(h, cmd_for_handle))
         }
 
         Command::Executable(executable) => {
@@ -151,18 +152,20 @@ fn launch_stage(
                 StageError::Inherit => Stdio::inherit(),
             };
             let args_strs: Vec<String> = args.iter().map(|a| a.to_string()).collect();
-            std::process::Command::new(executable.file_path())
+            match std::process::Command::new(executable.file_path())
                 .args(args_strs)
                 .current_dir(&ctx.cwd)
                 .stdin(stdin_stdio)
                 .stdout(stdout_stdio)
                 .stderr(stderr_stdio)
                 .spawn()
-                .map(StageHandle::Process)
-                .map_err(|e| ShellError::InCommand {
+            {
+                Ok(child) => Ok(StageHandle::Process(child, Command::Executable(executable))),
+                Err(e) => Err(ShellError::InCommand {
                     command: Command::Executable(executable),
                     source: Box::new(ShellError::ExecutionFailed(e)),
-                })
+                }),
+            }
         }
 
         Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
@@ -212,11 +215,21 @@ pub fn execute(
                 .stderr(stderr_stdio)
                 .spawn()
                 .map_err(|e| ShellError::InCommand {
-                    command: Command::Executable(executable),
+                    command: Command::Executable(executable.clone()),
                     source: Box::new(ShellError::ExecutionFailed(e)),
                 })?;
-            let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-            if status.success() { Ok(None) } else { Err(ShellError::NonZeroExit(status)) }
+            let status = child.wait().map_err(|e| ShellError::InCommand {
+                command: Command::Executable(executable.clone()),
+                source: Box::new(ShellError::ExecutionFailed(e)),
+            })?;
+            if status.success() {
+                Ok(None)
+            } else {
+                Err(ShellError::InCommand {
+                    command: Command::Executable(executable),
+                    source: Box::new(ShellError::NonZeroExit(status)),
+                })
+            }
         }
         Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
             name: String::from_utf8_lossy(&cmd).into_owned(),
@@ -232,7 +245,7 @@ pub fn execute(
 /// in-process buffering; output of the last stage goes to the inherited process
 /// stdout and stderr fds.
 ///
-/// Returns `Ok(Some(code))` when any stage requests shell exit, `Ok(None)` otherwise.
+/// Returns `Ok(Some(code))` when the last stage requests shell exit, `Ok(None)` otherwise.
 pub fn execute_pipeline(
     pipeline: Pipeline,
     ctx: &mut ShellCtx,
@@ -260,6 +273,9 @@ pub fn execute_pipeline(
         let stdin: Option<PipeReader> = if i == 0 { None } else { readers[i - 1].take() };
 
         let stdout = if let Some(r) = stdout_redirect {
+            if i < n - 1 {
+                writers[i].take(); // close write end so downstream sees EOF
+            }
             StageOutput::File(open_redirect_file(&r.mode, &r.target, &ctx.cwd)?)
         } else if i < n - 1 {
             StageOutput::Pipe(writers[i].take().unwrap())
@@ -272,26 +288,61 @@ pub fn execute_pipeline(
             None => StageError::Inherit,
         };
 
-        handles.push(launch_stage(command, args, stdin, stdout, stderr, ctx)?);
+        match launch_stage(command, args, stdin, stdout, stderr, ctx) {
+            Ok(handle) => handles.push(handle),
+            Err(launch_err) => {
+                drop(readers);
+                drop(writers);
+                for handle in handles {
+                    match handle {
+                        StageHandle::Thread(h, _) => { let _ = h.join(); }
+                        StageHandle::Process(mut child, _) => { let _ = child.wait(); }
+                    }
+                }
+                return Err(launch_err);
+            }
+        }
     }
 
     let mut first_error: Option<ShellError> = None;
     let mut exit_request: Option<ExitCode> = None;
+    let last = n - 1;
 
-    for handle in handles {
+    for (i, handle) in handles.into_iter().enumerate() {
         let result = match handle {
-            StageHandle::Thread(h) => h.join().unwrap_or_else(|_| {
-                Err(ShellError::Io(std::io::Error::other("pipeline stage thread panicked")))
+            StageHandle::Thread(h, command) => h.join().unwrap_or_else(|_| {
+                Err(ShellError::InCommand {
+                    command,
+                    source: Box::new(ShellError::Io(std::io::Error::other(
+                        "pipeline stage thread panicked",
+                    ))),
+                })
             }),
-            StageHandle::Process(mut child) => {
-                let status = child.wait().map_err(ShellError::ExecutionFailed)?;
-                if status.success() { Ok(None) } else { Err(ShellError::NonZeroExit(status)) }
+            StageHandle::Process(mut child, command) => {
+                let status = child.wait().map_err(|e| ShellError::InCommand {
+                    command: command.clone(),
+                    source: Box::new(ShellError::ExecutionFailed(e)),
+                })?;
+                if status.success() {
+                    Ok(None)
+                } else {
+                    Err(ShellError::InCommand {
+                        command,
+                        source: Box::new(ShellError::NonZeroExit(status)),
+                    })
+                }
             }
         };
         match result {
-            Ok(Some(code)) => exit_request = Some(code),
-            Ok(None) => {}
-            Err(e) if first_error.is_none() => first_error = Some(e),
+            Ok(Some(code)) if i == last => exit_request = Some(code),
+            Ok(_) => {}
+            Err(e) if first_error.is_none() => {
+                if i < last && is_broken_pipe(&e) {
+                    // upstream stage killed by downstream exit — expected, not an error
+                } else {
+                    first_error = Some(e);
+                }
+            }
             Err(_) => {}
         }
     }
@@ -301,6 +352,26 @@ pub fn execute_pipeline(
     } else {
         Ok(exit_request)
     }
+}
+
+fn is_broken_pipe(e: &ShellError) -> bool {
+    match e {
+        ShellError::Io(io_err) => io_err.kind() == std::io::ErrorKind::BrokenPipe,
+        ShellError::InCommand { source, .. } => is_broken_pipe(source),
+        ShellError::NonZeroExit(status) => exit_status_is_sigpipe(status),
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+fn exit_status_is_sigpipe(status: &std::process::ExitStatus) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal() == Some(13) // SIGPIPE
+}
+
+#[cfg(not(unix))]
+fn exit_status_is_sigpipe(_: &std::process::ExitStatus) -> bool {
+    false
 }
 
 fn execute_builtin(

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -296,7 +296,7 @@ pub fn execute_pipeline(
                 for handle in handles {
                     match handle {
                         StageHandle::Thread(h, _) => { let _ = h.join(); }
-                        StageHandle::Process(mut child, _) => { let _ = child.wait(); }
+                        StageHandle::Process(mut child, _) => { let _ = child.kill(); let _ = child.wait(); }
                     }
                 }
                 return Err(launch_err);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -377,11 +377,12 @@ fn exit_status_is_sigpipe(_: &std::process::ExitStatus) -> bool {
 fn execute_builtin(
     builtin: &BuiltInCommand,
     args: Args,
-    _stdin: Option<PipeReader>,
+    stdin: Option<PipeReader>,
     out: &mut dyn Write,
     err: &mut dyn Write,
     ctx: &mut ShellCtx,
 ) -> ShellResult<Option<ExitCode>> {
+    let _stdin_guard = stdin; // keep read end open until builtin completes
     match builtin.name() {
         BuiltInName::Exit => {
             let code = match args.first() {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -63,7 +63,7 @@ impl Shell {
                     continue;
                 }
             };
-            match executor::execute_pipeline(pipeline, out, err, &mut self.ctx) {
+            match executor::execute_pipeline(pipeline, &mut self.ctx) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -21,24 +21,21 @@ impl Shell {
         ShellBuilder::default()
     }
 
-    /// Run the interactive REPL loop, reading from stdin and writing to
-    /// stdout/stderr until `exit` is called or stdin is exhausted.
+    /// Run the interactive REPL loop, reading from stdin until `exit` is called
+    /// or stdin is exhausted. Prompts and diagnostics go to the process's real
+    /// stdout/stderr.
     pub fn run(&mut self) -> miette::Result<ExitCode> {
         let stdin = std::io::stdin();
         let mut reader = BufReader::new(stdin.lock());
-        let mut out = std::io::stdout();
-        let mut err = std::io::stderr();
-        self.run_repl(&mut reader, &mut out, &mut err)
+        self.run_repl(&mut reader)
     }
 
-    /// Run the REPL loop with injectable I/O — useful for testing prompt
-    /// behavior and other REPL properties without spawning a subprocess.
-    pub fn run_repl(
-        &mut self,
-        reader: &mut dyn BufRead,
-        out: &mut dyn Write,
-        err: &mut dyn Write,
-    ) -> miette::Result<ExitCode> {
+    /// Run the REPL loop with injectable stdin — useful for driving the shell
+    /// from a script or test without spawning a subprocess. Prompts and
+    /// diagnostics still go to the process's real stdout/stderr.
+    pub fn run_repl(&mut self, reader: &mut dyn BufRead) -> miette::Result<ExitCode> {
+        let mut out = std::io::stdout();
+        let mut err = std::io::stderr();
         loop {
             out.write_all(self.ctx.config.prompt.as_bytes()).into_diagnostic()?;
             out.flush().into_diagnostic()?;
@@ -77,7 +74,6 @@ impl Shell {
             }
         }
     }
-
 }
 
 /// Builder for constructing a [`Shell`] with custom configuration.
@@ -130,45 +126,24 @@ impl ShellBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
-
-    fn run_with_prompt(prompt: &str, input: &str) -> String {
-        let mut shell = Shell::builder().with_prompt(prompt.to_string()).build();
-        let mut reader = Cursor::new(input.as_bytes().to_vec());
-        let mut out = Vec::<u8>::new();
-        let mut err = Vec::<u8>::new();
-        shell.run_repl(&mut reader, &mut out, &mut err).unwrap();
-        String::from_utf8(out).unwrap()
-    }
 
     #[test]
     fn with_prompt_sets_prompt_string() {
-        let out = run_with_prompt("TEST> ", "");
-        assert!(out.contains("TEST> "), "expected custom prompt in output, got: {out:?}");
+        let shell = Shell::builder().with_prompt("TEST> ".to_string()).build();
+        assert_eq!(shell.ctx.config.prompt, "TEST> ");
     }
 
     #[test]
     fn with_config_sets_prompt() {
         let config = ShellConfig { prompt: "CFG> ".to_string(), ..Default::default() };
-        let mut shell = Shell::builder().with_config(config).build();
-        let mut reader = Cursor::new(b"".to_vec());
-        let mut out = Vec::<u8>::new();
-        let mut err = Vec::<u8>::new();
-        shell.run_repl(&mut reader, &mut out, &mut err).unwrap();
-        let stdout = String::from_utf8(out).unwrap();
-        assert!(stdout.contains("CFG> "), "expected config prompt, got: {stdout:?}");
+        let shell = Shell::builder().with_config(config).build();
+        assert_eq!(shell.ctx.config.prompt, "CFG> ");
     }
 
     #[test]
     fn with_prompt_overrides_with_config_prompt() {
         let config = ShellConfig { prompt: "CONFIG> ".to_string(), ..Default::default() };
-        let mut shell = Shell::builder().with_config(config).with_prompt("OVERRIDE> ".to_string()).build();
-        let mut reader = Cursor::new(b"".to_vec());
-        let mut out = Vec::<u8>::new();
-        let mut err = Vec::<u8>::new();
-        shell.run_repl(&mut reader, &mut out, &mut err).unwrap();
-        let stdout = String::from_utf8(out).unwrap();
-        assert!(stdout.contains("OVERRIDE> "), "expected override prompt, got: {stdout:?}");
-        assert!(!stdout.contains("CONFIG> "), "config prompt should be overridden");
+        let shell = Shell::builder().with_config(config).with_prompt("OVERRIDE> ".to_string()).build();
+        assert_eq!(shell.ctx.config.prompt, "OVERRIDE> ");
     }
 }

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -125,18 +125,21 @@ fn pipeline_builtin_receives_piped_stdin() {
 
 #[cfg(unix)]
 #[test]
-fn pipeline_aborts_on_first_stage_failure() {
+fn pipeline_first_stage_failure_surfaces_error() {
+    // With concurrent execution, builtin stages run before we can observe
+    // an earlier executable failure — matching POSIX bash behavior.  The
+    // important invariant is that the failure is still reported.
     ShellHarness::new()
         .run("false | echo should_not_run")
-        .assert_stdout_not_contains("should_not_run");
+        .assert_stderr_contains("exited with");
 }
 
 #[cfg(unix)]
 #[test]
-fn pipeline_aborts_on_middle_stage_failure() {
+fn pipeline_middle_stage_failure_surfaces_error() {
     ShellHarness::new()
         .run("echo a | false | echo should_not_run")
-        .assert_stdout_not_contains("should_not_run");
+        .assert_stderr_contains("exited with");
 }
 
 #[cfg(unix)]
@@ -154,4 +157,34 @@ fn pipeline_all_stages_succeed_no_error() {
         .run("echo hello | cat")
         .assert_stdout_contains("hello")
         .assert_stderr_empty();
+}
+
+// --- OS-level concurrent pipe correctness ---
+
+#[cfg(unix)]
+#[test]
+fn pipeline_large_data_no_deadlock() {
+    // Pipe more than a single pipe-buffer's worth of data (64 KB on Linux)
+    // through a 3-stage pipeline.  A serial/buffered implementation would
+    // not deadlock here, but a concurrent implementation with a misconfigured
+    // drain would.  Primarily validates that the OS-level pipe model does not
+    // stall under backpressure.
+    let out = ShellHarness::new().run("yes | head -c 131072 | wc -c");
+    let count: usize = out
+        .stdout()
+        .split_whitespace()
+        .find_map(|t| t.parse().ok())
+        .unwrap_or_else(|| panic!("expected byte count in: {:?}", out.stdout()));
+    assert_eq!(count, 131072, "expected 131072 bytes through pipeline");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipeline_builtin_cd_in_middle_does_not_change_shell_cwd() {
+    // A `cd` builtin in a non-last pipeline position runs in a cloned ctx
+    // (POSIX subshell semantics).  The shell's working directory must be
+    // unaffected after the pipeline completes.
+    let out = ShellHarness::new().run("echo x | cd /tmp | cat\npwd");
+    // pwd should print the temp home dir, not /tmp
+    out.assert_stdout_not_contains("/tmp");
 }

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -184,7 +184,8 @@ fn pipeline_builtin_cd_in_middle_does_not_change_shell_cwd() {
     // A `cd` builtin in a non-last pipeline position runs in a cloned ctx
     // (POSIX subshell semantics).  The shell's working directory must be
     // unaffected after the pipeline completes.
-    let out = ShellHarness::new().run("echo x | cd /tmp | cat\npwd");
-    // pwd should print the temp home dir, not /tmp
-    out.assert_stdout_not_contains("/tmp");
+    let out = ShellHarness::new().run("echo x | cd / | cat\npwd");
+    // pwd should print the temp home dir, not /
+    let home = out.home_dir().to_string_lossy().into_owned();
+    out.assert_stdout_contains(&home);
 }


### PR DESCRIPTION
Replace serial buffered pipeline execution with OS-level concurrent pipes and a unified stage dispatch.

## What changed

- `launch_stage` is the single dispatch point for all pipeline stages — builtin or executable. Each stage receives resolved `StageOutput`/`StageError` destinations and returns a `StageHandle` that is waited on uniformly.
- N-1 `std::io::pipe()` pairs are created up-front, consumed during launch, and never held by the parent after stages are running. No intermediate buffering; data flows through kernel pipe buffers between stages.
- All pipeline builtins run in a background thread with a cloned `ShellCtx` (POSIX subshell semantics — side-effects like `cd` do not propagate back). Standalone builtins (single command, no pipe) continue to run synchronously in the real `ctx` so state-mutation propagates normally.
- `StageHandle` carries its `Command` so wait failures, non-zero exits, and thread panics are all wrapped in `ShellError::InCommand` for consistent, attributed error messages.
- SIGPIPE / `BrokenPipe` on non-last stages is suppressed — this is the normal mechanism by which a downstream consumer signals producers to stop (e.g. `yes | head -c 1024`).
- Exit requests (`exit` builtin) only propagate from the last pipeline stage; earlier stages run in subshells per POSIX.
- Partial pipeline launch failures clean up already-started stages before returning.

## Removed

`execute_stage_inner`, `execute_stage_capture`, `execute_stage_with_stdin`, all drain thread infrastructure (`spawn_drain_thread`, `drain_and_wait`, etc.), `StageOutput::Terminal`, `StageError::Terminal`, `StageHandle::Done`.

Closes #28