### PR TITLE
fix: return EmptyPipelineSegment error for empty pipeline segments

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -107,7 +107,11 @@ pub enum ShellError {
         code(ferrish::parse::empty_pipeline_segment),
         help("each `|` must be preceded and followed by a command")
     )]
-    EmptyPipelineSegment,
+    EmptyPipelineSegment {
+        /// Byte offset of the `|` operator that produced an empty segment.
+        #[label("unexpected token")]
+        span: SourceSpan,
+    },
 }
 
 impl std::borrow::Borrow<dyn miette::Diagnostic> for Box<ShellError> {
@@ -142,6 +146,10 @@ impl PartialEq for ShellError {
                     span: r_span,
                 },
             ) => l_style == r_style && l_span == r_span,
+            (
+                Self::EmptyPipelineSegment { span: l_span },
+                Self::EmptyPipelineSegment { span: r_span },
+            ) => l_span == r_span,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,14 @@ pub enum ShellError {
         #[label("quote opened here")]
         span: SourceSpan,
     },
+
+    /// A pipeline segment (between `|` operators) is empty.
+    #[error("syntax error near unexpected token `|'")]
+    #[diagnostic(
+        code(ferrish::parse::empty_pipeline_segment),
+        help("each `|` must be preceded and followed by a command")
+    )]
+    EmptyPipelineSegment,
 }
 
 impl std::borrow::Borrow<dyn miette::Diagnostic> for Box<ShellError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,9 +40,20 @@ pub type Pipeline = Vec<PipelineStage>;
 /// appears inside quotes is treated as a literal argument character.
 pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
     let segments = split_pipeline_segments(buffer);
-    for segment in &segments {
+    for (i, segment) in segments.iter().enumerate() {
         if segment.trim_ascii().is_empty() {
-            return Err(ShellError::EmptyPipelineSegment);
+            let seg_offset = segment.as_ptr() as usize - buffer.as_ptr() as usize;
+            // The `|` that produced this empty segment is either:
+            // - after the segment for leading/middle empties (segment ends just before the `|`)
+            // - before the segment for trailing empties (the last segment has no following `|`)
+            let pipe_offset = if i + 1 < segments.len() {
+                seg_offset + segment.len()
+            } else {
+                seg_offset.saturating_sub(1)
+            };
+            return Err(ShellError::EmptyPipelineSegment {
+                span: SourceSpan::from((pipe_offset, 1)),
+            });
         }
     }
     let mut pipeline = Vec::with_capacity(segments.len());
@@ -985,25 +996,84 @@ mod tests {
     #[test]
     fn test_trailing_pipe_returns_empty_segment_error() {
         let err = parse(b"echo hello |").unwrap_err();
-        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+        assert!(
+            matches!(err, ShellError::EmptyPipelineSegment { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_trailing_pipe_span_points_at_pipe() {
+        // "echo hello |" — `|` is at byte 11
+        let err = parse(b"echo hello |").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span } = err {
+            assert_eq!(span.offset(), 11, "`|` is at byte 11 in 'echo hello |'");
+            assert_eq!(span.len(), 1);
+        } else {
+            panic!("expected EmptyPipelineSegment");
+        }
     }
 
     #[test]
     fn test_leading_pipe_returns_empty_segment_error() {
         let err = parse(b"| cat").unwrap_err();
-        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+        assert!(
+            matches!(err, ShellError::EmptyPipelineSegment { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_leading_pipe_span_points_at_pipe() {
+        // "| cat" — `|` is at byte 0
+        let err = parse(b"| cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span } = err {
+            assert_eq!(span.offset(), 0, "`|` is at byte 0 in '| cat'");
+            assert_eq!(span.len(), 1);
+        } else {
+            panic!("expected EmptyPipelineSegment");
+        }
     }
 
     #[test]
     fn test_empty_middle_segment_returns_error() {
         let err = parse(b"echo a | | cat").unwrap_err();
-        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+        assert!(
+            matches!(err, ShellError::EmptyPipelineSegment { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_empty_middle_segment_span_points_at_second_pipe() {
+        // "echo a | | cat" — second `|` is at byte 9
+        let err = parse(b"echo a | | cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span } = err {
+            assert_eq!(span.offset(), 9, "second `|` is at byte 9 in 'echo a | | cat'");
+            assert_eq!(span.len(), 1);
+        } else {
+            panic!("expected EmptyPipelineSegment");
+        }
     }
 
     #[test]
     fn test_whitespace_only_segment_returns_error() {
         let err = parse(b"echo a |   | cat").unwrap_err();
-        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+        assert!(
+            matches!(err, ShellError::EmptyPipelineSegment { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_only_segment_span_points_at_second_pipe() {
+        // "echo a |   | cat" — second `|` is at byte 11
+        let err = parse(b"echo a |   | cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span } = err {
+            assert_eq!(span.offset(), 11, "second `|` is at byte 11 in 'echo a |   | cat'");
+        } else {
+            panic!("expected EmptyPipelineSegment");
+        }
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,6 +40,11 @@ pub type Pipeline = Vec<PipelineStage>;
 /// appears inside quotes is treated as a literal argument character.
 pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
     let segments = split_pipeline_segments(buffer);
+    for segment in &segments {
+        if segment.trim_ascii().is_empty() {
+            return Err(ShellError::EmptyPipelineSegment);
+        }
+    }
     let mut pipeline = Vec::with_capacity(segments.len());
     for segment in segments {
         // Compute the segment's byte offset within the original buffer via
@@ -973,5 +978,43 @@ mod tests {
         let (_, _, stdout_redir, _) = &p[1];
         let r = stdout_redir.as_ref().expect("last stage should have redirect");
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
+    }
+
+    // --- EmptyPipelineSegment tests ---
+
+    #[test]
+    fn test_trailing_pipe_returns_empty_segment_error() {
+        let err = parse(b"echo hello |").unwrap_err();
+        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_leading_pipe_returns_empty_segment_error() {
+        let err = parse(b"| cat").unwrap_err();
+        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_empty_middle_segment_returns_error() {
+        let err = parse(b"echo a | | cat").unwrap_err();
+        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_whitespace_only_segment_returns_error() {
+        let err = parse(b"echo a |   | cat").unwrap_err();
+        assert!(matches!(err, ShellError::EmptyPipelineSegment), "got: {err:?}");
+    }
+
+    #[test]
+    fn test_empty_pipeline_segment_is_non_fatal() {
+        let err = parse(b"echo hello |").unwrap_err();
+        assert!(!err.is_fatal());
+    }
+
+    #[test]
+    fn test_empty_pipeline_segment_display() {
+        let err = parse(b"| cat").unwrap_err();
+        assert!(err.to_string().contains("|"), "expected `|` in error message, got: {err}");
     }
 }

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -159,6 +159,29 @@ fn pipeline_all_stages_succeed_no_error() {
         .assert_stderr_empty();
 }
 
+// --- Malformed pipeline segment errors ---
+
+#[test]
+fn trailing_pipe_reports_error_and_continues() {
+    let out = ShellHarness::new().run("echo hello |\necho survived");
+    out.assert_stderr_contains("|")
+        .assert_stdout_contains("survived");
+}
+
+#[test]
+fn leading_pipe_reports_error_and_continues() {
+    let out = ShellHarness::new().run("| cat\necho survived");
+    out.assert_stderr_contains("|")
+        .assert_stdout_contains("survived");
+}
+
+#[test]
+fn empty_middle_segment_reports_error_and_continues() {
+    let out = ShellHarness::new().run("echo a | | cat\necho survived");
+    out.assert_stderr_contains("|")
+        .assert_stdout_contains("survived");
+}
+
 // --- OS-level concurrent pipe correctness ---
 
 #[cfg(unix)]

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -165,21 +165,26 @@ fn pipeline_all_stages_succeed_no_error() {
 fn trailing_pipe_reports_error_and_continues() {
     let out = ShellHarness::new().run("echo hello |\necho survived");
     out.assert_stderr_contains("|")
-        .assert_stdout_contains("survived");
+        .assert_stdout_contains("survived")
+        .assert_stdout_not_contains("hello")
+        .assert_exit_code(0);
 }
 
 #[test]
 fn leading_pipe_reports_error_and_continues() {
     let out = ShellHarness::new().run("| cat\necho survived");
     out.assert_stderr_contains("|")
-        .assert_stdout_contains("survived");
+        .assert_stdout_contains("survived")
+        .assert_exit_code(0);
 }
 
 #[test]
 fn empty_middle_segment_reports_error_and_continues() {
     let out = ShellHarness::new().run("echo a | | cat\necho survived");
     out.assert_stderr_contains("|")
-        .assert_stdout_contains("survived");
+        .assert_stdout_contains("survived")
+        .assert_stdout_not_contains("a\n")
+        .assert_exit_code(0);
 }
 
 // --- OS-level concurrent pipe correctness ---


### PR DESCRIPTION
Empty pipeline segments — trailing `echo hello |`, leading `| cat`, and middle `echo a | | cat` — previously reached the executor as an empty `Unrecognized` command, producing a confusing "command not found" error. They now return a new non-fatal `ShellError::EmptyPipelineSegment` from the parser, which the REPL prints to stderr and recovers from, consistent with how `UnclosedQuote` is handled.

Closes #93