### PR TITLE
feat: self-contained parse error diagnostics via Input type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +193,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "ferrish"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "clap",
  "is_executable",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 rust-version = "1.92"
 
 [dependencies]
+bytes = "1"
 clap = { version = "4", features = ["derive"] }
 is_executable = "1.0"
 miette = { version = "7", features = ["fancy"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::process::ExitStatus;
 
 use crate::arg::{Arg, QuoteStyle};
 use crate::command::Command;
-use miette::{Diagnostic, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
 
 /// Convenience result type for shell execution results
@@ -96,9 +96,12 @@ pub enum ShellError {
     UnclosedQuote {
         /// The kind of quote that was opened but never closed.
         style: QuoteStyle,
-        /// Byte offset of the opening quote character in the trimmed input line passed to the parser.
+        /// Absolute byte offset of the opening quote character in the raw input line.
         #[label("quote opened here")]
         span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: NamedSource<String>,
     },
 
     /// A pipeline segment (between `|` operators) is empty.
@@ -108,9 +111,12 @@ pub enum ShellError {
         help("each `|` must be preceded and followed by a command")
     )]
     EmptyPipelineSegment {
-        /// Byte offset of the `|` operator that produced an empty segment.
+        /// Absolute byte offset of the `|` operator that produced an empty segment.
         #[label("unexpected token")]
         span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: NamedSource<String>,
     },
 }
 
@@ -137,18 +143,12 @@ impl PartialEq for ShellError {
                 Self::InCommand { command: rc, source: rs },
             ) => lc == rc && ls == rs,
             (
-                Self::UnclosedQuote {
-                    style: l_style,
-                    span: l_span,
-                },
-                Self::UnclosedQuote {
-                    style: r_style,
-                    span: r_span,
-                },
+                Self::UnclosedQuote { style: l_style, span: l_span, .. },
+                Self::UnclosedQuote { style: r_style, span: r_span, .. },
             ) => l_style == r_style && l_span == r_span,
             (
-                Self::EmptyPipelineSegment { span: l_span },
-                Self::EmptyPipelineSegment { span: r_span },
+                Self::EmptyPipelineSegment { span: l_span, .. },
+                Self::EmptyPipelineSegment { span: r_span, .. },
             ) => l_span == r_span,
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
@@ -181,6 +181,10 @@ impl ShellError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dummy_src() -> NamedSource<String> {
+        NamedSource::new("<test>", String::new())
+    }
 
     #[test]
     fn test_display_command_not_found() {
@@ -239,6 +243,7 @@ mod tests {
         let err = ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((0, 1)),
+            src: dummy_src(),
         };
         assert_eq!(err.to_string(), "unclosed Single quote");
     }
@@ -248,6 +253,7 @@ mod tests {
         let err = ShellError::UnclosedQuote {
             style: QuoteStyle::Double,
             span: SourceSpan::from((5, 1)),
+            src: dummy_src(),
         };
         assert_eq!(err.to_string(), "unclosed Double quote");
     }
@@ -303,6 +309,7 @@ mod tests {
         let err = ShellError::UnclosedQuote {
             style: QuoteStyle::Double,
             span: SourceSpan::from((0, 1)),
+            src: dummy_src(),
         };
         assert!(!err.is_fatal());
     }
@@ -362,10 +369,12 @@ mod tests {
         let e1 = ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((3, 1)),
+            src: dummy_src(),
         };
         let e2 = ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((3, 1)),
+            src: dummy_src(),
         };
         assert_eq!(e1, e2);
     }
@@ -375,10 +384,12 @@ mod tests {
         let e1 = ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((3, 1)),
+            src: dummy_src(),
         };
         let e2 = ShellError::UnclosedQuote {
             style: QuoteStyle::Double,
             span: SourceSpan::from((3, 1)),
+            src: dummy_src(),
         };
         assert_ne!(e1, e2);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,8 @@ use std::process::ExitStatus;
 
 use crate::arg::{Arg, QuoteStyle};
 use crate::command::Command;
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use crate::input::InputSource;
+use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
 /// Convenience result type for shell execution results
@@ -101,7 +102,7 @@ pub enum ShellError {
         span: SourceSpan,
         /// The raw input line this error was produced from.
         #[source_code]
-        src: NamedSource<String>,
+        src: InputSource,
     },
 
     /// A pipeline segment (between `|` operators) is empty.
@@ -116,7 +117,7 @@ pub enum ShellError {
         span: SourceSpan,
         /// The raw input line this error was produced from.
         #[source_code]
-        src: NamedSource<String>,
+        src: InputSource,
     },
 }
 
@@ -181,9 +182,10 @@ impl ShellError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::Input;
 
-    fn dummy_src() -> NamedSource<String> {
-        NamedSource::new("<test>", String::new())
+    fn dummy_src() -> InputSource {
+        Input::new(b"").as_source()
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,15 +1,53 @@
-use miette::NamedSource;
+use bytes::Bytes;
+use miette::{MietteError, MietteSpanContents, SourceCode, SourceSpan, SpanContents};
 
-/// A raw input line as received from the user, with the trimmed view and
-/// leading-whitespace offset pre-computed.
+/// A named, byte-accurate miette source backed by a [`Bytes`] buffer.
+///
+/// Implements [`SourceCode`] so it can be used directly as the `#[source_code]`
+/// field in diagnostic variants. Cloning is cheap — the underlying [`Bytes`]
+/// is reference-counted.
+#[derive(Clone, Debug)]
+pub struct InputSource {
+    name: &'static str,
+    bytes: Bytes,
+}
+
+impl InputSource {
+    fn new(name: &'static str, bytes: Bytes) -> Self {
+        Self { name, bytes }
+    }
+}
+
+impl SourceCode for InputSource {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+        let bytes: &'a [u8] = &self.bytes;
+        let inner = bytes.read_span(span, context_lines_before, context_lines_after)?;
+        Ok(Box::new(MietteSpanContents::new_named(
+            self.name.to_string(),
+            inner.data(),
+            *inner.span(),
+            inner.line(),
+            inner.column(),
+            inner.line_count(),
+        )))
+    }
+}
+
+/// A raw input line as received from the user, with byte-accurate storage and
+/// pre-computed trimming metadata.
 ///
 /// The parser operates on [`Input::trimmed_bytes`] but constructs all
-/// diagnostic spans as absolute offsets into [`Input::raw_str`], so errors
+/// diagnostic spans as absolute offsets into the raw byte sequence, so errors
 /// are self-contained and render correctly without any adjustment at the
 /// call site.
 pub struct Input {
-    raw: String,
-    /// Byte offset of the first non-whitespace character in `raw`.
+    raw: Bytes,
+    /// Byte offset of the first non-whitespace byte in `raw`.
     leading_offset: usize,
     /// Byte length of the trimmed content (trailing whitespace excluded).
     trimmed_len: usize,
@@ -18,19 +56,18 @@ pub struct Input {
 impl Input {
     /// Construct an [`Input`] from raw bytes as received from the user.
     pub fn new(bytes: &[u8]) -> Self {
-        let raw = String::from_utf8_lossy(bytes).into_owned();
-        let raw_bytes = raw.as_bytes();
-        let leading_offset = raw_bytes.len() - raw_bytes.trim_ascii_start().len();
-        let trimmed_len = raw_bytes.trim_ascii().len();
+        let raw = Bytes::copy_from_slice(bytes);
+        let leading_offset = raw.len() - raw.trim_ascii_start().len();
+        let trimmed_len = raw.trim_ascii().len();
         Self { raw, leading_offset, trimmed_len }
     }
 
     /// The slice the parser operates on — leading and trailing whitespace removed.
     pub fn trimmed_bytes(&self) -> &[u8] {
-        &self.raw.as_bytes()[self.leading_offset..self.leading_offset + self.trimmed_len]
+        &self.raw[self.leading_offset..self.leading_offset + self.trimmed_len]
     }
 
-    /// Byte offset of the trimmed content within the raw string.
+    /// Byte offset of the trimmed content within the raw byte sequence.
     pub fn leading_offset(&self) -> usize {
         self.leading_offset
     }
@@ -40,15 +77,15 @@ impl Input {
         self.trimmed_len == 0
     }
 
-    /// The original input string as received, including all whitespace.
-    pub fn raw_str(&self) -> &str {
+    /// The original bytes as received, including all whitespace.
+    pub fn raw_bytes(&self) -> &[u8] {
         &self.raw
     }
 
-    /// A named miette source wrapping the raw input line, suitable for
-    /// embedding directly in diagnostic variants via `#[source_code]`.
-    pub fn named_source(&self) -> NamedSource<String> {
-        NamedSource::new("<input>", self.raw.clone())
+    /// A named miette source suitable for embedding in diagnostic variants via
+    /// `#[source_code]`. Cloning is cheap — the underlying buffer is reference-counted.
+    pub fn as_source(&self) -> InputSource {
+        InputSource::new("<input>", self.raw.clone())
     }
 }
 
@@ -86,8 +123,16 @@ mod tests {
     }
 
     #[test]
-    fn raw_str_preserves_original() {
+    fn raw_bytes_preserves_original() {
         let input = Input::new(b"  echo hello\n");
-        assert_eq!(input.raw_str(), "  echo hello\n");
+        assert_eq!(input.raw_bytes(), b"  echo hello\n");
+    }
+
+    #[test]
+    fn non_utf8_bytes_stored_accurately() {
+        let bytes = b"echo \xff\xfe";
+        let input = Input::new(bytes);
+        assert_eq!(input.raw_bytes(), bytes);
+        assert_eq!(input.trimmed_bytes(), bytes); // no leading/trailing whitespace
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -54,12 +54,32 @@ pub struct Input {
 }
 
 impl Input {
-    /// Construct an [`Input`] from raw bytes as received from the user.
-    pub fn new(bytes: &[u8]) -> Self {
-        let raw = Bytes::copy_from_slice(bytes);
+    fn from_raw(raw: Bytes) -> Self {
         let leading_offset = raw.len() - raw.trim_ascii_start().len();
         let trimmed_len = raw.trim_ascii().len();
-        Self { raw, leading_offset, trimmed_len }
+        Self {
+            raw,
+            leading_offset,
+            trimmed_len,
+        }
+    }
+
+    /// Construct an [`Input`] from borrowed raw bytes, copying into owned storage.
+    ///
+    /// Prefer [`Input::from_vec`] or [`Input::from_bytes`] when the caller already
+    /// owns the buffer to avoid the extra copy.
+    pub fn new(bytes: &[u8]) -> Self {
+        Self::from_raw(Bytes::copy_from_slice(bytes))
+    }
+
+    /// Construct an [`Input`] from an owned [`Vec<u8>`] without an extra copy.
+    pub fn from_vec(bytes: Vec<u8>) -> Self {
+        Self::from_raw(Bytes::from(bytes))
+    }
+
+    /// Construct an [`Input`] from an owned [`Bytes`] buffer without an extra copy.
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        Self::from_raw(bytes)
     }
 
     /// The slice the parser operates on — leading and trailing whitespace removed.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,93 @@
+use miette::NamedSource;
+
+/// A raw input line as received from the user, with the trimmed view and
+/// leading-whitespace offset pre-computed.
+///
+/// The parser operates on [`Input::trimmed_bytes`] but constructs all
+/// diagnostic spans as absolute offsets into [`Input::raw_str`], so errors
+/// are self-contained and render correctly without any adjustment at the
+/// call site.
+pub struct Input {
+    raw: String,
+    /// Byte offset of the first non-whitespace character in `raw`.
+    leading_offset: usize,
+    /// Byte length of the trimmed content (trailing whitespace excluded).
+    trimmed_len: usize,
+}
+
+impl Input {
+    /// Construct an [`Input`] from raw bytes as received from the user.
+    pub fn new(bytes: &[u8]) -> Self {
+        let raw = String::from_utf8_lossy(bytes).into_owned();
+        let raw_bytes = raw.as_bytes();
+        let leading_offset = raw_bytes.len() - raw_bytes.trim_ascii_start().len();
+        let trimmed_len = raw_bytes.trim_ascii().len();
+        Self { raw, leading_offset, trimmed_len }
+    }
+
+    /// The slice the parser operates on — leading and trailing whitespace removed.
+    pub fn trimmed_bytes(&self) -> &[u8] {
+        &self.raw.as_bytes()[self.leading_offset..self.leading_offset + self.trimmed_len]
+    }
+
+    /// Byte offset of the trimmed content within the raw string.
+    pub fn leading_offset(&self) -> usize {
+        self.leading_offset
+    }
+
+    /// Returns `true` if the input contains only whitespace.
+    pub fn is_effectively_empty(&self) -> bool {
+        self.trimmed_len == 0
+    }
+
+    /// The original input string as received, including all whitespace.
+    pub fn raw_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// A named miette source wrapping the raw input line, suitable for
+    /// embedding directly in diagnostic variants via `#[source_code]`.
+    pub fn named_source(&self) -> NamedSource<String> {
+        NamedSource::new("<input>", self.raw.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trimmed_bytes_strips_whitespace() {
+        let input = Input::new(b"  echo hello  \n");
+        assert_eq!(input.trimmed_bytes(), b"echo hello");
+    }
+
+    #[test]
+    fn leading_offset_counts_leading_bytes() {
+        let input = Input::new(b"  echo hello");
+        assert_eq!(input.leading_offset(), 2);
+    }
+
+    #[test]
+    fn leading_offset_zero_for_no_leading_whitespace() {
+        let input = Input::new(b"echo hello");
+        assert_eq!(input.leading_offset(), 0);
+    }
+
+    #[test]
+    fn is_effectively_empty_for_whitespace_only() {
+        assert!(Input::new(b"   \t\n").is_effectively_empty());
+        assert!(Input::new(b"").is_effectively_empty());
+    }
+
+    #[test]
+    fn is_effectively_empty_false_for_content() {
+        assert!(!Input::new(b"  echo  ").is_effectively_empty());
+    }
+
+    #[test]
+    fn raw_str_preserves_original() {
+        let input = Input::new(b"  echo hello\n");
+        assert_eq!(input.raw_str(), "  echo hello\n");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod executor;
 pub mod exit;
 /// Filesystem path utilities.
 pub mod fs;
+/// Raw input line with trimmed view and leading-offset pre-computed.
+pub mod input;
 /// Input parsing: splits raw bytes into a command and its arguments.
 pub mod parser;
 /// I/O redirection descriptors produced by the parser.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,6 +9,7 @@ use crate::command::executable::ExecutableCommand;
 use crate::command::{Command, builtin};
 use crate::env::get_path_files;
 use crate::error::ShellError;
+use crate::input::Input;
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 
 /// One stage of a pipeline: the command to run, its arguments, and any
@@ -38,7 +39,8 @@ pub type Pipeline = Vec<PipelineStage>;
 /// When the same fd appears more than once, the **last** operator wins.
 /// Only unquoted redirect operators are recognised; an operator character that
 /// appears inside quotes is treated as a literal argument character.
-pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
+pub fn parse(input: &Input) -> Result<Pipeline, ShellError> {
+    let buffer = input.trimmed_bytes();
     let segments = split_pipeline_segments(buffer);
     for (i, segment) in segments.iter().enumerate() {
         if segment.trim_ascii().is_empty() {
@@ -52,40 +54,27 @@ pub fn parse(buffer: &[u8]) -> Result<Pipeline, ShellError> {
                 seg_offset.saturating_sub(1)
             };
             return Err(ShellError::EmptyPipelineSegment {
-                span: SourceSpan::from((pipe_offset, 1)),
+                span: SourceSpan::from((input.leading_offset() + pipe_offset, 1)),
+                src: input.named_source(),
             });
         }
     }
     let mut pipeline = Vec::with_capacity(segments.len());
     for segment in segments {
-        // Compute the segment's byte offset within the original buffer via
-        // pointer arithmetic so that error spans are relative to the full line.
-        // Also account for leading whitespace that `split_command_and_args`
-        // trims internally — without this correction, spans in later pipeline
-        // stages would be off by the number of leading spaces after `|`.
-        let offset = segment.as_ptr() as usize - buffer.as_ptr() as usize;
-        let leading_ws = segment.len() - segment.trim_ascii_start().len();
-        pipeline.push(parse_segment(segment).map_err(|e| adjust_span(e, offset + leading_ws))?);
+        // Absolute byte offset of this segment's first byte within the raw input.
+        let abs_start = input.leading_offset() + (segment.as_ptr() as usize - buffer.as_ptr() as usize);
+        pipeline.push(parse_segment(segment, abs_start, input)?);
     }
     Ok(pipeline)
 }
 
-/// Shift a [`ShellError::UnclosedQuote`] span by `delta` bytes so it is
-/// relative to the full input line rather than the per-segment slice.
-fn adjust_span(error: ShellError, delta: usize) -> ShellError {
-    match error {
-        ShellError::UnclosedQuote { style, span } => ShellError::UnclosedQuote {
-            style,
-            span: SourceSpan::from((span.offset() + delta, span.len())),
-        },
-        other => other,
-    }
-}
-
 /// Parse a single pipeline segment (bytes between `|` operators) into a
 /// [`PipelineStage`].
-fn parse_segment(buffer: &[u8]) -> Result<PipelineStage, ShellError> {
-    let (command, raw_args) = split_command_and_args(buffer)?;
+///
+/// `abs_start` is the byte offset of `buffer[0]` within the raw input line,
+/// used to anchor all diagnostic spans to the original string.
+fn parse_segment(buffer: &[u8], abs_start: usize, input: &Input) -> Result<PipelineStage, ShellError> {
+    let (command, raw_args) = split_command_and_args(buffer, abs_start, input)?;
     let command = parse_command(&command);
 
     let (args, stdout_redirect, stderr_redirect) = extract_redirects(raw_args);
@@ -230,8 +219,11 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
 /// Adjacent quoted and unquoted segments are concatenated into a single token.
 ///
 /// Returns `Err(ShellError::UnclosedQuote)` if a quote is opened but never closed.
-fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), ShellError> {
-    let buffer = buffer.trim_ascii();
+fn split_command_and_args(
+    buffer: &[u8],
+    abs_start: usize,
+    input: &Input,
+) -> Result<(Vec<u8>, Vec<RawArg>), ShellError> {
     let mut parts: Vec<(Vec<u8>, QuoteStyle)> = Vec::new();
 
     let mut current: Vec<u8> = Vec::new();
@@ -239,7 +231,7 @@ fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), Shell
     let mut in_double_quote = false;
     let mut token_started = false;
     let mut token_style: Option<QuoteStyle> = None;
-    // Byte offset of the opening quote character (relative to the trimmed buffer).
+    // Absolute byte offset of the opening quote character within the raw input.
     let mut quote_open_pos: usize = 0;
 
     let mut i = 0;
@@ -282,7 +274,7 @@ fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), Shell
             };
         } else if byte == b'\'' {
             in_single_quote = true;
-            quote_open_pos = i;
+            quote_open_pos = abs_start + i;
             token_started = true;
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Single);
@@ -291,7 +283,7 @@ fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), Shell
             }
         } else if byte == b'"' {
             in_double_quote = true;
-            quote_open_pos = i;
+            quote_open_pos = abs_start + i;
             token_started = true;
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Double);
@@ -320,12 +312,14 @@ fn split_command_and_args(buffer: &[u8]) -> Result<(Vec<u8>, Vec<RawArg>), Shell
         return Err(ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((quote_open_pos, 1)),
+            src: input.named_source(),
         });
     }
     if in_double_quote {
         return Err(ShellError::UnclosedQuote {
             style: QuoteStyle::Double,
             span: SourceSpan::from((quote_open_pos, 1)),
+            src: input.named_source(),
         });
     }
 
@@ -378,16 +372,22 @@ pub fn parse_arg(arg: &[u8]) -> Arg {
 mod tests {
     use super::*;
 
+    fn parse_raw(raw: &[u8]) -> Result<Pipeline, ShellError> {
+        parse(&Input::new(raw))
+    }
+
     // Helper: split and return command + arg bytes (quoting metadata stripped).
     fn split(input: &[u8]) -> (Vec<u8>, Vec<Vec<u8>>) {
-        let (cmd, args) = split_command_and_args(input).unwrap();
+        let src = Input::new(input);
+        let (cmd, args) = split_command_and_args(input, 0, &src).unwrap();
         let arg_bytes = args.into_iter().map(|(b, _)| b).collect();
         (cmd, arg_bytes)
     }
 
     // Helper: split and return command + (bytes, style) pairs.
     fn split_styled(input: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>) {
-        split_command_and_args(input).unwrap()
+        let src = Input::new(input);
+        split_command_and_args(input, 0, &src).unwrap()
     }
 
     #[test]
@@ -670,24 +670,21 @@ mod tests {
 
     #[test]
     fn test_unclosed_double_quote_returns_error() {
-        let result = split_command_and_args(b"echo \"hello");
+        let buf = b"echo \"hello";
+        let src = Input::new(buf);
+        let result = split_command_and_args(buf, 0, &src);
         let err = result.unwrap_err();
         assert!(
-            matches!(
-                err,
-                ShellError::UnclosedQuote {
-                    style: QuoteStyle::Double,
-                    ..
-                }
-            ),
+            matches!(err, ShellError::UnclosedQuote { style: QuoteStyle::Double, .. }),
             "expected UnclosedQuote(Double), got: {err:?}"
         );
     }
 
     #[test]
     fn test_unclosed_double_quote_span_offset() {
-        let result = split_command_and_args(b"echo \"hello");
-        let err = result.unwrap_err();
+        let buf = b"echo \"hello";
+        let src = Input::new(buf);
+        let err = split_command_and_args(buf, 0, &src).unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
             assert_eq!(span.offset(), 5, "quote opens at byte 5 in 'echo \"hello'");
         } else {
@@ -697,24 +694,21 @@ mod tests {
 
     #[test]
     fn test_unclosed_single_quote_returns_error() {
-        let result = split_command_and_args(b"echo 'hello");
+        let buf = b"echo 'hello";
+        let src = Input::new(buf);
+        let result = split_command_and_args(buf, 0, &src);
         let err = result.unwrap_err();
         assert!(
-            matches!(
-                err,
-                ShellError::UnclosedQuote {
-                    style: QuoteStyle::Single,
-                    ..
-                }
-            ),
+            matches!(err, ShellError::UnclosedQuote { style: QuoteStyle::Single, .. }),
             "expected UnclosedQuote(Single), got: {err:?}"
         );
     }
 
     #[test]
     fn test_unclosed_single_quote_span_offset() {
-        let result = split_command_and_args(b"echo 'hello");
-        let err = result.unwrap_err();
+        let buf = b"echo 'hello";
+        let src = Input::new(buf);
+        let err = split_command_and_args(buf, 0, &src).unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
             assert_eq!(span.offset(), 5, "quote opens at byte 5 in \"echo 'hello\"");
         } else {
@@ -724,33 +718,31 @@ mod tests {
 
     #[test]
     fn test_unclosed_quote_is_non_fatal() {
-        let result = split_command_and_args(b"echo \"unterminated");
-        let err = result.unwrap_err();
+        let buf = b"echo \"unterminated";
+        let src = Input::new(buf);
+        let err = split_command_and_args(buf, 0, &src).unwrap_err();
         assert!(!err.is_fatal());
     }
 
     #[test]
     fn test_pipeline_unclosed_quote_span_accounts_for_leading_whitespace() {
         // The second segment has one leading space after `|`.
-        // The `"` opens at byte 5 within the trimmed segment `echo "bar`,
-        // which starts at byte 10 in the full input (`echo foo |`).
-        // With the leading-space correction (+1), the span should be at byte 16.
-        let input = b"echo foo | echo \"bar";
-        let err = parse(input).unwrap_err();
+        // The `"` opens at position 6 within ` echo "bar` (the raw segment),
+        // which starts at byte 10 in the full input. abs_start = 10, i = 6 → span = 16.
+        let raw = b"echo foo | echo \"bar";
+        let input = Input::new(raw);
+        let err = parse(&input).unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
-            assert_eq!(
-                span.offset(),
-                16,
-                "quote `\"` is at byte 16 in the full input"
-            );
+            assert_eq!(span.offset(), 16, "quote `\"` is at byte 16 in the full input");
         } else {
             panic!("expected UnclosedQuote, got: {err:?}");
         }
     }
 
     // Helper: parse a single-stage command (no `|`) and extract the one stage.
-    fn parse_single(input: &[u8]) -> PipelineStage {
-        let mut pipeline = parse(input).unwrap();
+    fn parse_single(raw: &[u8]) -> PipelineStage {
+        let input = Input::new(raw);
+        let mut pipeline = parse(&input).unwrap();
         assert_eq!(pipeline.len(), 1, "expected exactly one pipeline stage");
         pipeline.remove(0)
     }
@@ -941,13 +933,13 @@ mod tests {
 
     #[test]
     fn test_pipeline_single_command_gives_one_stage() {
-        let p = parse(b"echo hello").unwrap();
+        let p = parse_raw(b"echo hello").unwrap();
         assert_eq!(p.len(), 1);
     }
 
     #[test]
     fn test_pipeline_two_commands_gives_two_stages() {
-        let p = parse(b"echo foo | cat").unwrap();
+        let p = parse_raw(b"echo foo | cat").unwrap();
         assert_eq!(p.len(), 2);
         let (cmd0, args0, _, _) = &p[0];
         let (cmd1, args1, _, _) = &p[1];
@@ -962,7 +954,7 @@ mod tests {
 
     #[test]
     fn test_pipeline_quoted_pipe_is_not_separator() {
-        let p = parse(b"echo 'foo | bar'").unwrap();
+        let p = parse_raw(b"echo 'foo | bar'").unwrap();
         assert_eq!(p.len(), 1, "quoted | must not split the pipeline");
         let (_, args, _, _) = &p[0];
         assert_eq!(
@@ -973,7 +965,7 @@ mod tests {
 
     #[test]
     fn test_pipeline_double_quoted_pipe_is_not_separator() {
-        let p = parse(b"echo \"foo | bar\"").unwrap();
+        let p = parse_raw(b"echo \"foo | bar\"").unwrap();
         assert_eq!(p.len(), 1, "double-quoted | must not split the pipeline");
         let (_, args, _, _) = &p[0];
         assert_eq!(
@@ -984,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_pipeline_last_stage_redirect() {
-        let p = parse(b"echo foo | cat > out.txt").unwrap();
+        let p = parse_raw(b"echo foo | cat > out.txt").unwrap();
         assert_eq!(p.len(), 2);
         let (_, _, stdout_redir, _) = &p[1];
         let r = stdout_redir.as_ref().expect("last stage should have redirect");
@@ -995,7 +987,7 @@ mod tests {
 
     #[test]
     fn test_trailing_pipe_returns_empty_segment_error() {
-        let err = parse(b"echo hello |").unwrap_err();
+        let err = parse_raw(b"echo hello |").unwrap_err();
         assert!(
             matches!(err, ShellError::EmptyPipelineSegment { .. }),
             "got: {err:?}"
@@ -1005,8 +997,8 @@ mod tests {
     #[test]
     fn test_trailing_pipe_span_points_at_pipe() {
         // "echo hello |" — `|` is at byte 11
-        let err = parse(b"echo hello |").unwrap_err();
-        if let ShellError::EmptyPipelineSegment { span } = err {
+        let err = parse_raw(b"echo hello |").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 11, "`|` is at byte 11 in 'echo hello |'");
             assert_eq!(span.len(), 1);
         } else {
@@ -1016,7 +1008,7 @@ mod tests {
 
     #[test]
     fn test_leading_pipe_returns_empty_segment_error() {
-        let err = parse(b"| cat").unwrap_err();
+        let err = parse_raw(b"| cat").unwrap_err();
         assert!(
             matches!(err, ShellError::EmptyPipelineSegment { .. }),
             "got: {err:?}"
@@ -1026,8 +1018,8 @@ mod tests {
     #[test]
     fn test_leading_pipe_span_points_at_pipe() {
         // "| cat" — `|` is at byte 0
-        let err = parse(b"| cat").unwrap_err();
-        if let ShellError::EmptyPipelineSegment { span } = err {
+        let err = parse_raw(b"| cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 0, "`|` is at byte 0 in '| cat'");
             assert_eq!(span.len(), 1);
         } else {
@@ -1037,7 +1029,7 @@ mod tests {
 
     #[test]
     fn test_empty_middle_segment_returns_error() {
-        let err = parse(b"echo a | | cat").unwrap_err();
+        let err = parse_raw(b"echo a | | cat").unwrap_err();
         assert!(
             matches!(err, ShellError::EmptyPipelineSegment { .. }),
             "got: {err:?}"
@@ -1047,8 +1039,8 @@ mod tests {
     #[test]
     fn test_empty_middle_segment_span_points_at_second_pipe() {
         // "echo a | | cat" — second `|` is at byte 9
-        let err = parse(b"echo a | | cat").unwrap_err();
-        if let ShellError::EmptyPipelineSegment { span } = err {
+        let err = parse_raw(b"echo a | | cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 9, "second `|` is at byte 9 in 'echo a | | cat'");
             assert_eq!(span.len(), 1);
         } else {
@@ -1058,7 +1050,7 @@ mod tests {
 
     #[test]
     fn test_whitespace_only_segment_returns_error() {
-        let err = parse(b"echo a |   | cat").unwrap_err();
+        let err = parse_raw(b"echo a |   | cat").unwrap_err();
         assert!(
             matches!(err, ShellError::EmptyPipelineSegment { .. }),
             "got: {err:?}"
@@ -1068,8 +1060,8 @@ mod tests {
     #[test]
     fn test_whitespace_only_segment_span_points_at_second_pipe() {
         // "echo a |   | cat" — second `|` is at byte 11
-        let err = parse(b"echo a |   | cat").unwrap_err();
-        if let ShellError::EmptyPipelineSegment { span } = err {
+        let err = parse_raw(b"echo a |   | cat").unwrap_err();
+        if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 11, "second `|` is at byte 11 in 'echo a |   | cat'");
         } else {
             panic!("expected EmptyPipelineSegment");
@@ -1078,13 +1070,13 @@ mod tests {
 
     #[test]
     fn test_empty_pipeline_segment_is_non_fatal() {
-        let err = parse(b"echo hello |").unwrap_err();
+        let err = parse_raw(b"echo hello |").unwrap_err();
         assert!(!err.is_fatal());
     }
 
     #[test]
     fn test_empty_pipeline_segment_display() {
-        let err = parse(b"| cat").unwrap_err();
+        let err = parse_raw(b"| cat").unwrap_err();
         assert!(err.to_string().contains("|"), "expected `|` in error message, got: {err}");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ pub fn parse(input: &Input) -> Result<Pipeline, ShellError> {
             };
             return Err(ShellError::EmptyPipelineSegment {
                 span: SourceSpan::from((input.leading_offset() + pipe_offset, 1)),
-                src: input.named_source(),
+                src: input.as_source(),
             });
         }
     }
@@ -203,7 +203,7 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
     (out_args, stdout_redirect, stderr_redirect)
 }
 
-/// Split the trimmed input buffer into a command token and zero or more argument tokens.
+/// Split a pipeline segment into a command token and zero or more argument tokens.
 ///
 /// Handles single-quoted strings: characters inside `'...'` are treated literally —
 /// whitespace is preserved (not used as a delimiter) and backslashes have no special
@@ -312,14 +312,14 @@ fn split_command_and_args(
         return Err(ShellError::UnclosedQuote {
             style: QuoteStyle::Single,
             span: SourceSpan::from((quote_open_pos, 1)),
-            src: input.named_source(),
+            src: input.as_source(),
         });
     }
     if in_double_quote {
         return Err(ShellError::UnclosedQuote {
             style: QuoteStyle::Double,
             span: SourceSpan::from((quote_open_pos, 1)),
-            src: input.named_source(),
+            src: input.as_source(),
         });
     }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -7,6 +7,7 @@ use crate::{
     ctx::{ShellConfig, ShellCtx},
     executor,
     exit::ExitCode,
+    input::Input,
     parser,
 };
 
@@ -40,32 +41,31 @@ impl Shell {
             out.write_all(self.ctx.config.prompt.as_bytes()).into_diagnostic()?;
             out.flush().into_diagnostic()?;
 
-            let mut buffer = Vec::<u8>::new();
-            let bytes = reader.read_until(b'\n', &mut buffer).into_diagnostic()?;
+            let mut raw = Vec::<u8>::new();
+            let bytes = reader.read_until(b'\n', &mut raw).into_diagnostic()?;
             if bytes == 0 {
                 return Ok(ExitCode::SUCCESS);
             }
 
-            let buffer = buffer.trim_ascii();
-            if buffer.is_empty() {
+            let input = Input::new(&raw);
+            if input.is_effectively_empty() {
                 continue;
             }
 
-            let make_src = || String::from_utf8_lossy(buffer).into_owned();
-            let pipeline = match parser::parse(buffer) {
+            let pipeline = match parser::parse(&input) {
                 Ok(r) => r,
                 Err(e) => {
-                    let report = miette::Report::new(e).with_source_code(make_src());
-                    writeln!(err, "{report:?}").into_diagnostic()?;
+                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
                     continue;
                 }
             };
+            let raw_src = input.raw_str().to_owned();
             match executor::execute_pipeline(pipeline, &mut self.ctx) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
-                    let report = miette::Report::new(e).with_source_code(make_src());
+                    let report = miette::Report::new(e).with_source_code(raw_src);
                     writeln!(err, "{report:?}").into_diagnostic()?;
                     if fatal {
                         return Ok(ExitCode::FAILURE);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -59,13 +59,12 @@ impl Shell {
                     continue;
                 }
             };
-            let raw_src = input.raw_str().to_owned();
             match executor::execute_pipeline(pipeline, &mut self.ctx) {
                 Ok(Some(exit_code)) => return Ok(exit_code),
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
-                    let report = miette::Report::new(e).with_source_code(raw_src);
+                    let report = miette::Report::new(e).with_source_code(input.as_source());
                     writeln!(err, "{report:?}").into_diagnostic()?;
                     if fatal {
                         return Ok(ExitCode::FAILURE);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -38,7 +38,8 @@ impl Shell {
         let mut out = std::io::stdout();
         let mut err = std::io::stderr();
         loop {
-            out.write_all(self.ctx.config.prompt.as_bytes()).into_diagnostic()?;
+            out.write_all(self.ctx.config.prompt.as_bytes())
+                .into_diagnostic()?;
             out.flush().into_diagnostic()?;
 
             let mut raw = Vec::<u8>::new();
@@ -47,7 +48,7 @@ impl Shell {
                 return Ok(ExitCode::SUCCESS);
             }
 
-            let input = Input::new(&raw);
+            let input = Input::from_vec(raw);
             if input.is_effectively_empty() {
                 continue;
             }
@@ -134,15 +135,24 @@ mod tests {
 
     #[test]
     fn with_config_sets_prompt() {
-        let config = ShellConfig { prompt: "CFG> ".to_string(), ..Default::default() };
+        let config = ShellConfig {
+            prompt: "CFG> ".to_string(),
+            ..Default::default()
+        };
         let shell = Shell::builder().with_config(config).build();
         assert_eq!(shell.ctx.config.prompt, "CFG> ");
     }
 
     #[test]
     fn with_prompt_overrides_with_config_prompt() {
-        let config = ShellConfig { prompt: "CONFIG> ".to_string(), ..Default::default() };
-        let shell = Shell::builder().with_config(config).with_prompt("OVERRIDE> ".to_string()).build();
+        let config = ShellConfig {
+            prompt: "CONFIG> ".to_string(),
+            ..Default::default()
+        };
+        let shell = Shell::builder()
+            .with_config(config)
+            .with_prompt("OVERRIDE> ".to_string())
+            .build();
         assert_eq!(shell.ctx.config.prompt, "OVERRIDE> ");
     }
 }


### PR DESCRIPTION
## Summary

- Introduces `src/input.rs`: the `Input` type wraps the raw input line with its trimmed view and leading-whitespace offset pre-computed, giving the parser a single object that carries everything it needs to build correct diagnostics
- `parser::parse` now takes `&Input` instead of `&[u8]`; `parse_segment` and `split_command_and_args` receive an `abs_start: usize` parameter and construct spans as absolute byte offsets into the raw string directly — `adjust_span` is gone
- `UnclosedQuote` and `EmptyPipelineSegment` embed `#[source_code] src: NamedSource<String>`, so `miette::Report::new(e)` renders with the correct source snippet and caret position without any adjustment at the render boundary
- `shell.rs` no longer pre-trims input or calls `.with_source_code()` on parse errors; executor errors retain `.with_source_code()` pending #111

## Test plan

- [ ] `cargo test` — all 136 unit and integration tests pass
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Manually verify: feed `  echo "hello` (with leading spaces) to the REPL and confirm the caret in the diagnostic points at the `"` in the raw input, not the trimmed string

Closes #92

Co-Authored-By: Claude <noreply@anthropic.com>