### PR TITLE
feat: carry source context and spans through executor errors

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
 
+use miette::SourceSpan;
+
+use crate::input::InputSource;
+
 /// A list of shell command arguments.
 pub type Args = Vec<Arg>;
 
@@ -22,54 +26,95 @@ pub enum QuoteStyle {
     Double,
 }
 
-/// Represents a shell command argument.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Represents a shell command argument produced by the parser.
+///
+/// Every `Arg` carries the byte offset and source of the token as it appeared
+/// in the original input line, so executor errors can embed self-contained
+/// diagnostic labels without any additional context threading.
+#[derive(Debug, Clone)]
 pub enum Arg {
-    /// A raw byte sequence with no preserved quoting metadata.
-    ///
-    /// This variant is treated as unquoted when quote context matters, but it
-    /// does not by itself imply anything about how the value was originally
-    /// constructed or parsed.
-    Literal(Vec<u8>),
-    /// A byte sequence with its quoting origin preserved.
+    /// An unquoted token.
+    Literal {
+        /// The parsed byte content.
+        bytes: Vec<u8>,
+        /// Byte offset and length of this token in the raw input line.
+        span: SourceSpan,
+        /// The raw input line this token was parsed from.
+        src: InputSource,
+    },
+    /// A token whose quoting origin is preserved.
     Quoted {
-        /// The raw byte content of the argument.
+        /// The parsed byte content (quotes stripped, escapes resolved).
         bytes: Vec<u8>,
         /// The quoting context in which this argument was parsed.
         style: QuoteStyle,
+        /// Byte offset and length of this token in the raw input line.
+        span: SourceSpan,
+        /// The raw input line this token was parsed from.
+        src: InputSource,
     },
 }
 
 impl Arg {
-    /// Returns the raw bytes of this argument, regardless of quoting.
+    /// Construct a synthetic argument with no source location.
+    ///
+    /// Use only in tests or for arguments that are not derived from user input.
+    pub fn synthetic(bytes: &[u8]) -> Self {
+        Arg::Literal {
+            bytes: bytes.to_vec(),
+            span: SourceSpan::from((0, 0)),
+            src: InputSource::synthetic(),
+        }
+    }
+
+    /// The parsed byte content of this argument.
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            Arg::Literal(bytes) | Arg::Quoted { bytes, .. } => bytes,
+            Arg::Literal { bytes, .. } | Arg::Quoted { bytes, .. } => bytes,
+        }
+    }
+
+    /// Byte offset and length of this token in the raw input line.
+    pub fn span(&self) -> SourceSpan {
+        match self {
+            Arg::Literal { span, .. } | Arg::Quoted { span, .. } => *span,
+        }
+    }
+
+    /// The raw input source this token was parsed from.
+    pub fn src(&self) -> InputSource {
+        match self {
+            Arg::Literal { src, .. } | Arg::Quoted { src, .. } => src.clone(),
         }
     }
 }
 
+impl PartialEq for Arg {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Arg::Literal { bytes: a, .. }, Arg::Literal { bytes: b, .. }) => a == b,
+            (
+                Arg::Quoted {
+                    bytes: a,
+                    style: sa,
+                    ..
+                },
+                Arg::Quoted {
+                    bytes: b,
+                    style: sb,
+                    ..
+                },
+            ) => a == b && sa == sb,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Arg {}
+
 impl std::fmt::Display for Arg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", String::from_utf8_lossy(self.as_bytes()))
-    }
-}
-
-impl From<&str> for Arg {
-    fn from(val: &str) -> Self {
-        Arg::from(val.as_bytes())
-    }
-}
-
-impl From<&[u8]> for Arg {
-    fn from(val: &[u8]) -> Self {
-        Arg::from(val.to_vec())
-    }
-}
-
-impl From<Vec<u8>> for Arg {
-    fn from(val: Vec<u8>) -> Self {
-        Arg::Literal(val)
     }
 }
 
@@ -84,48 +129,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_arg_from_str() {
-        let arg = Arg::from("hello");
+    fn synthetic_as_bytes() {
+        let arg = Arg::synthetic(b"hello");
         assert_eq!(arg.as_bytes(), b"hello");
-        assert!(matches!(arg, Arg::Literal(_)));
+        assert!(matches!(arg, Arg::Literal { .. }));
     }
 
     #[test]
-    fn test_arg_display() {
-        let arg = Arg::from("display_test");
+    fn display_renders_bytes() {
+        let arg = Arg::synthetic(b"display_test");
         assert_eq!(arg.to_string(), "display_test");
     }
 
     #[test]
-    fn test_arg_equality() {
-        let arg1 = Arg::from("same");
-        let arg2 = Arg::from("same");
+    fn equality_ignores_span_and_src() {
+        let arg1 = Arg::synthetic(b"same");
+        let arg2 = Arg::synthetic(b"same");
         assert_eq!(arg1, arg2);
     }
 
     #[test]
-    fn test_arg_to_pathbuf() {
-        let arg = Arg::from("/path/to/file");
+    fn to_pathbuf() {
+        let arg = Arg::synthetic(b"/path/to/file");
         let pathbuf = PathBuf::from(&arg);
         assert_eq!(pathbuf, PathBuf::from("/path/to/file"));
     }
 
     #[test]
-    fn test_quoted_single_as_bytes() {
+    fn quoted_as_bytes() {
         let arg = Arg::Quoted {
-            bytes: b"hello".to_vec(),
+            bytes: b"hello world".to_vec(),
             style: QuoteStyle::Single,
+            span: SourceSpan::from((0, 13)),
+            src: InputSource::synthetic(),
         };
-        assert_eq!(arg.as_bytes(), b"hello");
-        assert_eq!(arg.to_string(), "hello");
-    }
-
-    #[test]
-    fn test_quoted_double_as_bytes() {
-        let arg = Arg::Quoted {
-            bytes: b"world".to_vec(),
-            style: QuoteStyle::Double,
-        };
-        assert_eq!(arg.as_bytes(), b"world");
+        assert_eq!(arg.as_bytes(), b"hello world");
+        assert_eq!(arg.to_string(), "hello world");
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,25 +1,53 @@
 use std::fmt::Display;
 
+use miette::SourceSpan;
+
+use crate::input::InputSource;
+
 pub(crate) mod builtin;
 pub(crate) mod executable;
 
 /// Represents a shell command.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Command {
     /// A shell built-in command (e.g. `echo`, `cd`, `exit`).
     BuiltIn(builtin::BuiltInCommand),
     /// An external executable found on `PATH`.
     Executable(executable::ExecutableCommand),
     /// A command token that could not be resolved to a built-in or executable.
-    Unrecognized(Vec<u8>),
+    Unrecognized {
+        /// The raw bytes of the unrecognized command token.
+        bytes: Vec<u8>,
+        /// Byte offset and length of this token in the raw input line.
+        span: SourceSpan,
+        /// The raw input line this token was parsed from.
+        src: InputSource,
+    },
 }
+
+impl PartialEq for Command {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Command::BuiltIn(a), Command::BuiltIn(b)) => a == b,
+            (Command::Executable(a), Command::Executable(b)) => a == b,
+            (Command::Unrecognized { bytes: a, .. }, Command::Unrecognized { bytes: b, .. }) => {
+                a == b
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Command {}
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Command::BuiltIn(builtin) => write!(f, "{}", builtin),
             Command::Executable(executable) => write!(f, "{}", executable),
-            Command::Unrecognized(bytes) => write!(f, "{}", String::from_utf8_lossy(bytes)),
+            Command::Unrecognized { bytes, .. } => {
+                write!(f, "{}", String::from_utf8_lossy(bytes))
+            }
         }
     }
 }

--- a/src/command/executable.rs
+++ b/src/command/executable.rs
@@ -51,5 +51,4 @@ mod tests {
         let cmd = ExecutableCommand::new(path.clone());
         assert_eq!(cmd.file_path(), &path);
     }
-
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::process::ExitStatus;
 
-use crate::arg::{Arg, QuoteStyle};
+use crate::arg::QuoteStyle;
 use crate::command::Command;
 use crate::input::InputSource;
 use miette::{Diagnostic, SourceSpan};
@@ -22,6 +22,12 @@ pub enum ShellError {
     CommandNotFound {
         /// The command name that was not found.
         name: String,
+        /// Byte offset of the command token in the raw input line.
+        #[label("command not found")]
+        span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: InputSource,
     },
 
     /// A required operand was not provided.
@@ -29,29 +35,52 @@ pub enum ShellError {
     #[diagnostic(code(ferrish::missing_operand))]
     MissingOperand,
 
+    /// The home directory could not be determined.
+    #[error("home directory not set")]
+    #[diagnostic(code(ferrish::home_not_set))]
+    HomeNotSet,
+
     // --- File system ---
     /// The path does not exist on the filesystem.
-    #[error("no such file or directory: {arg}")]
+    #[error("no such file or directory: {name}")]
     #[diagnostic(code(ferrish::fs::not_found))]
     FileNotFound {
-        /// The argument that referred to the missing path.
-        arg: Arg,
+        /// The path that was not found.
+        name: String,
+        /// Byte offset of the offending argument in the raw input line.
+        #[label("no such file or directory")]
+        span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: InputSource,
     },
 
     /// The path exists but is a directory where a regular file was expected.
-    #[error("is a directory: {arg}")]
+    #[error("is a directory: {name}")]
     #[diagnostic(code(ferrish::fs::is_a_directory))]
     IsADirectory {
-        /// The argument that referred to the directory.
-        arg: Arg,
+        /// The path that resolved to a directory.
+        name: String,
+        /// Byte offset of the offending argument in the raw input line.
+        #[label("is a directory")]
+        span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: InputSource,
     },
 
     /// The path exists but is a regular file where a directory was expected.
-    #[error("not a directory: {arg}")]
+    #[error("not a directory: {name}")]
     #[diagnostic(code(ferrish::fs::not_a_directory))]
     NotADirectory {
-        /// The argument that referred to the non-directory path.
-        arg: Arg,
+        /// The path that was not a directory.
+        name: String,
+        /// Byte offset of the offending argument in the raw input line.
+        #[label("not a directory")]
+        span: SourceSpan,
+        /// The raw input line this error was produced from.
+        #[source_code]
+        src: InputSource,
     },
 
     // --- Process execution ---
@@ -79,7 +108,6 @@ pub enum ShellError {
         #[diagnostic_source]
         source: Box<ShellError>,
     },
-
 
     // --- I/O ---
     /// An I/O error propagated from the underlying stream.
@@ -130,22 +158,40 @@ impl std::borrow::Borrow<dyn miette::Diagnostic> for Box<ShellError> {
 impl PartialEq for ShellError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::CommandNotFound { name: l }, Self::CommandNotFound { name: r }) => l == r,
-            (Self::FileNotFound { arg: la }, Self::FileNotFound { arg: ra }) => la == ra,
-            (Self::IsADirectory { arg: la }, Self::IsADirectory { arg: ra }) => la == ra,
-            (Self::NotADirectory { arg: la }, Self::NotADirectory { arg: ra }) => la == ra,
+            (Self::CommandNotFound { name: l, .. }, Self::CommandNotFound { name: r, .. }) => {
+                l == r
+            }
+            (Self::FileNotFound { name: la, .. }, Self::FileNotFound { name: ra, .. }) => la == ra,
+            (Self::IsADirectory { name: la, .. }, Self::IsADirectory { name: ra, .. }) => la == ra,
+            (Self::NotADirectory { name: la, .. }, Self::NotADirectory { name: ra, .. }) => {
+                la == ra
+            }
             (Self::NonZeroExit(l0), Self::NonZeroExit(r0)) => l0 == r0,
             (Self::ExecutionFailed(l0), Self::ExecutionFailed(r0)) => {
                 l0.raw_os_error() == r0.raw_os_error()
             }
             (Self::Io(l0), Self::Io(r0)) => l0.raw_os_error() == r0.raw_os_error(),
             (
-                Self::InCommand { command: lc, source: ls },
-                Self::InCommand { command: rc, source: rs },
+                Self::InCommand {
+                    command: lc,
+                    source: ls,
+                },
+                Self::InCommand {
+                    command: rc,
+                    source: rs,
+                },
             ) => lc == rc && ls == rs,
             (
-                Self::UnclosedQuote { style: l_style, span: l_span, .. },
-                Self::UnclosedQuote { style: r_style, span: r_span, .. },
+                Self::UnclosedQuote {
+                    style: l_style,
+                    span: l_span,
+                    ..
+                },
+                Self::UnclosedQuote {
+                    style: r_style,
+                    span: r_span,
+                    ..
+                },
             ) => l_style == r_style && l_span == r_span,
             (
                 Self::EmptyPipelineSegment { span: l_span, .. },
@@ -188,9 +234,17 @@ mod tests {
         Input::new(b"").as_source()
     }
 
+    fn dummy_span() -> SourceSpan {
+        SourceSpan::from((0, 0))
+    }
+
     #[test]
     fn test_display_command_not_found() {
-        let err = ShellError::CommandNotFound { name: "foo".to_string() };
+        let err = ShellError::CommandNotFound {
+            name: "foo".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err.to_string(), "foo: command not found");
     }
 
@@ -201,26 +255,48 @@ mod tests {
     }
 
     #[test]
+    fn test_display_home_not_set() {
+        let err = ShellError::HomeNotSet;
+        assert_eq!(err.to_string(), "home directory not set");
+    }
+
+    #[test]
     fn test_display_file_not_found() {
-        let err = ShellError::FileNotFound { arg: Arg::from("/path/to/file") };
+        let err = ShellError::FileNotFound {
+            name: "/path/to/file".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err.to_string(), "no such file or directory: /path/to/file");
     }
 
     #[test]
     fn test_display_is_a_directory() {
-        let err = ShellError::IsADirectory { arg: Arg::from("/some/dir") };
+        let err = ShellError::IsADirectory {
+            name: "/some/dir".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err.to_string(), "is a directory: /some/dir");
     }
 
     #[test]
     fn test_display_not_a_directory() {
-        let err = ShellError::NotADirectory { arg: Arg::from("/some/file") };
+        let err = ShellError::NotADirectory {
+            name: "/some/file".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err.to_string(), "not a directory: /some/file");
     }
 
     #[test]
     fn test_in_command_prepends_command_name() {
-        let inner = ShellError::FileNotFound { arg: Arg::from("/no/such") };
+        let inner = ShellError::FileNotFound {
+            name: "/no/such".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         let err = ShellError::InCommand {
             command: Command::BuiltIn(crate::command::builtin::BuiltInCommand::new(
                 crate::command::builtin::BuiltInName::Cd,
@@ -234,7 +310,11 @@ mod tests {
     fn test_in_command_fatal_delegates_to_source() {
         let inner = ShellError::ExecutionFailed(std::io::Error::last_os_error());
         let err = ShellError::InCommand {
-            command: Command::Unrecognized(b"mycmd".to_vec()),
+            command: Command::Unrecognized {
+                bytes: b"mycmd".to_vec(),
+                span: dummy_span(),
+                src: dummy_src(),
+            },
             source: Box::new(inner),
         };
         assert!(err.is_fatal());
@@ -276,7 +356,11 @@ mod tests {
         let status = ExitStatus::from_raw(2 << 8);
         let inner = ShellError::NonZeroExit(status);
         let err = ShellError::InCommand {
-            command: Command::Unrecognized(b"foo".to_vec()),
+            command: Command::Unrecognized {
+                bytes: b"foo".to_vec(),
+                span: dummy_span(),
+                src: dummy_src(),
+            },
             source: Box::new(inner),
         };
         assert_eq!(err.as_exit_status(), Some(status));
@@ -284,7 +368,11 @@ mod tests {
 
     #[test]
     fn test_as_exit_status_other_variants_return_none() {
-        let err = ShellError::CommandNotFound { name: "foo".to_string() };
+        let err = ShellError::CommandNotFound {
+            name: "foo".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err.as_exit_status(), None);
     }
 
@@ -296,13 +384,21 @@ mod tests {
 
     #[test]
     fn test_is_fatal_command_not_found() {
-        let err = ShellError::CommandNotFound { name: "foo".to_string() };
+        let err = ShellError::CommandNotFound {
+            name: "foo".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert!(!err.is_fatal());
     }
 
     #[test]
     fn test_is_fatal_file_not_found() {
-        let err = ShellError::FileNotFound { arg: Arg::from("test") };
+        let err = ShellError::FileNotFound {
+            name: "test".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert!(!err.is_fatal());
     }
 
@@ -318,21 +414,41 @@ mod tests {
 
     #[test]
     fn test_equality_file_not_found() {
-        let err1 = ShellError::FileNotFound { arg: Arg::from("file1") };
-        let err2 = ShellError::FileNotFound { arg: Arg::from("file1") };
+        let err1 = ShellError::FileNotFound {
+            name: "file1".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
+        let err2 = ShellError::FileNotFound {
+            name: "file1".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_eq!(err1, err2);
     }
 
     #[test]
     fn test_inequality_file_not_found() {
-        let err1 = ShellError::FileNotFound { arg: Arg::from("file1") };
-        let err2 = ShellError::FileNotFound { arg: Arg::from("file2") };
+        let err1 = ShellError::FileNotFound {
+            name: "file1".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
+        let err2 = ShellError::FileNotFound {
+            name: "file2".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         assert_ne!(err1, err2);
     }
 
     #[test]
     fn test_equality_different_variant() {
-        let err1 = ShellError::CommandNotFound { name: "foo".to_string() };
+        let err1 = ShellError::CommandNotFound {
+            name: "foo".to_string(),
+            span: dummy_span(),
+            src: dummy_src(),
+        };
         let err2 = ShellError::MissingOperand;
         assert_ne!(err1, err2);
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -7,7 +7,6 @@ use std::thread::{self, JoinHandle};
 use is_executable::IsExecutable;
 
 use crate::{
-    Arg, Command,
     arg::Args,
     command::builtin::{BuiltInCommand, BuiltInName},
     ctx::ShellCtx,
@@ -17,6 +16,7 @@ use crate::{
     fs,
     parser::Pipeline,
     redirect::{RedirectMode, StderrRedirection, StdoutRedirection},
+    Command,
 };
 
 enum CommandKind {
@@ -100,7 +100,6 @@ enum StageHandle {
     Process(Child, Command),
 }
 
-
 /// Single dispatch for launching any pipeline stage — builtin or executable.
 ///
 /// Both kinds receive resolved IO destinations via [`StageOutput`] and
@@ -131,11 +130,18 @@ fn launch_stage(
             };
             let mut ctx_clone = ctx.clone();
             let h = thread::spawn(move || {
-                execute_builtin(&builtin, args, stdin, &mut *out_w, &mut *err_w, &mut ctx_clone)
-                    .map_err(|e| ShellError::InCommand {
-                        command: Command::BuiltIn(builtin),
-                        source: Box::new(e),
-                    })
+                execute_builtin(
+                    &builtin,
+                    args,
+                    stdin,
+                    &mut *out_w,
+                    &mut *err_w,
+                    &mut ctx_clone,
+                )
+                .map_err(|e| ShellError::InCommand {
+                    command: Command::BuiltIn(builtin),
+                    source: Box::new(e),
+                })
             });
             Ok(StageHandle::Thread(h, cmd_for_handle))
         }
@@ -168,8 +174,10 @@ fn launch_stage(
             }
         }
 
-        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
-            name: String::from_utf8_lossy(&cmd).into_owned(),
+        Command::Unrecognized { bytes, span, src } => Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(&bytes).into_owned(),
+            span,
+            src,
         }),
     }
 }
@@ -200,7 +208,10 @@ pub fn execute(
             let out: &mut dyn Write = out_file.as_mut().map_or(&mut stdout_default as _, |f| f);
             let err: &mut dyn Write = err_file.as_mut().map_or(&mut stderr_default as _, |f| f);
             execute_builtin(&builtin, args, None, out, err, ctx).map_err(|e| {
-                ShellError::InCommand { command: Command::BuiltIn(builtin), source: Box::new(e) }
+                ShellError::InCommand {
+                    command: Command::BuiltIn(builtin),
+                    source: Box::new(e),
+                }
             })
         }
         Command::Executable(executable) => {
@@ -231,8 +242,10 @@ pub fn execute(
                 })
             }
         }
-        Command::Unrecognized(cmd) => Err(ShellError::CommandNotFound {
-            name: String::from_utf8_lossy(&cmd).into_owned(),
+        Command::Unrecognized { bytes, span, src } => Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(&bytes).into_owned(),
+            span,
+            src,
         }),
     }
 }
@@ -246,10 +259,7 @@ pub fn execute(
 /// stdout and stderr fds.
 ///
 /// Returns `Ok(Some(code))` when the last stage requests shell exit, `Ok(None)` otherwise.
-pub fn execute_pipeline(
-    pipeline: Pipeline,
-    ctx: &mut ShellCtx,
-) -> ShellResult<Option<ExitCode>> {
+pub fn execute_pipeline(pipeline: Pipeline, ctx: &mut ShellCtx) -> ShellResult<Option<ExitCode>> {
     if pipeline.len() == 1 {
         let (cmd, args, stdout_redir, stderr_redir) = pipeline.into_iter().next().unwrap();
         return execute(cmd, args, ctx, stdout_redir, stderr_redir);
@@ -267,9 +277,7 @@ pub fn execute_pipeline(
 
     let mut handles = Vec::with_capacity(n);
 
-    for (i, (command, args, stdout_redirect, stderr_redirect)) in
-        stages.into_iter().enumerate()
-    {
+    for (i, (command, args, stdout_redirect, stderr_redirect)) in stages.into_iter().enumerate() {
         let stdin: Option<PipeReader> = if i == 0 { None } else { readers[i - 1].take() };
 
         let stdout = if let Some(r) = stdout_redirect {
@@ -295,8 +303,13 @@ pub fn execute_pipeline(
                 drop(writers);
                 for handle in handles {
                     match handle {
-                        StageHandle::Thread(h, _) => { let _ = h.join(); }
-                        StageHandle::Process(mut child, _) => { let _ = child.kill(); let _ = child.wait(); }
+                        StageHandle::Thread(h, _) => {
+                            let _ = h.join();
+                        }
+                        StageHandle::Process(mut child, _) => {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
                     }
                 }
                 return Err(launch_err);
@@ -410,18 +423,30 @@ fn execute_builtin(
 }
 
 fn execute_cd(args: Args, ctx: &mut ShellCtx) -> ShellResult<()> {
-    let default_target = Arg::from(b"~".as_slice());
-    let target = args.first().unwrap_or(&default_target);
-    let new_dir = fs::resolve_path(&target.into(), ctx.home_dir.as_deref(), &ctx.cwd)?;
-
-    if !new_dir.exists() {
-        return Err(ShellError::FileNotFound { arg: target.clone() });
-    } else if !new_dir.is_dir() {
-        return Err(ShellError::NotADirectory { arg: target.clone() });
-    }
+    let new_dir = if let Some(target) = args.first() {
+        let path = fs::resolve_path(&target.into(), ctx.home_dir.as_deref(), &ctx.cwd)?;
+        if !path.exists() {
+            return Err(ShellError::FileNotFound {
+                name: target.to_string(),
+                span: target.span(),
+                src: target.src(),
+            });
+        } else if !path.is_dir() {
+            return Err(ShellError::NotADirectory {
+                name: target.to_string(),
+                span: target.span(),
+                src: target.src(),
+            });
+        }
+        path
+    } else {
+        ctx.home_dir
+            .as_deref()
+            .ok_or(ShellError::HomeNotSet)?
+            .to_path_buf()
+    };
 
     ctx.cwd = new_dir;
-
     Ok(())
 }
 
@@ -446,15 +471,17 @@ fn execute_type(args: Args, out: &mut dyn Write) -> ShellResult<()> {
     let name = arg.as_bytes();
 
     match resolve_command_type(name) {
-        CommandKind::Builtin(builtin_name) => {
-            writeln!(out, "{} is a shell builtin", builtin_name)?
-        }
+        CommandKind::Builtin(builtin_name) => writeln!(out, "{} is a shell builtin", builtin_name)?,
         CommandKind::Executable(path) => {
             let display_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
             writeln!(out, "{} is {}", display_name, path.display())?
         }
         CommandKind::NotFound => {
-            return Err(ShellError::CommandNotFound { name: arg.to_string() })
+            return Err(ShellError::CommandNotFound {
+                name: arg.to_string(),
+                span: arg.span(),
+                src: arg.src(),
+            })
         }
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -424,7 +424,13 @@ fn execute_builtin(
 
 fn execute_cd(args: Args, ctx: &mut ShellCtx) -> ShellResult<()> {
     let new_dir = if let Some(target) = args.first() {
-        let path = fs::resolve_path(&target.into(), ctx.home_dir.as_deref(), &ctx.cwd)?;
+        let target_path: std::path::PathBuf = target.into();
+        // Tilde expansion requires HOME; fail here so `cd ~` and `cd` both
+        // return HomeNotSet rather than `cd ~` silently going to `/`.
+        if target_path.strip_prefix("~").is_ok() && ctx.home_dir.is_none() {
+            return Err(ShellError::HomeNotSet);
+        }
+        let path = fs::resolve_path(&target_path, ctx.home_dir.as_deref(), &ctx.cwd)?;
         if !path.exists() {
             return Err(ShellError::FileNotFound {
                 name: target.to_string(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -16,6 +16,14 @@ impl InputSource {
     fn new(name: &'static str, bytes: Bytes) -> Self {
         Self { name, bytes }
     }
+
+    /// A zero-content source for synthetic tokens that have no real input origin.
+    pub(crate) fn synthetic() -> Self {
+        Self {
+            name: "<synthetic>",
+            bytes: Bytes::new(),
+        }
+    }
 }
 
 impl SourceCode for InputSource {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,15 +6,20 @@ use miette::SourceSpan;
 use crate::arg::{Arg, Args, QuoteStyle};
 use crate::command::builtin::BuiltInCommand;
 use crate::command::executable::ExecutableCommand;
-use crate::command::{Command, builtin};
+use crate::command::{builtin, Command};
 use crate::env::get_path_files;
 use crate::error::ShellError;
-use crate::input::Input;
+use crate::input::{Input, InputSource};
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 
 /// One stage of a pipeline: the command to run, its arguments, and any
 /// per-stage redirections.
-pub type PipelineStage = (Command, Args, Option<StdoutRedirection>, Option<StderrRedirection>);
+pub type PipelineStage = (
+    Command,
+    Args,
+    Option<StdoutRedirection>,
+    Option<StderrRedirection>,
+);
 
 /// A parsed pipeline — one [`PipelineStage`] per `|`-separated segment.
 ///
@@ -62,7 +67,8 @@ pub fn parse(input: &Input) -> Result<Pipeline, ShellError> {
     let mut pipeline = Vec::with_capacity(segments.len());
     for segment in segments {
         // Absolute byte offset of this segment's first byte within the raw input.
-        let abs_start = input.leading_offset() + (segment.as_ptr() as usize - buffer.as_ptr() as usize);
+        let abs_start =
+            input.leading_offset() + (segment.as_ptr() as usize - buffer.as_ptr() as usize);
         pipeline.push(parse_segment(segment, abs_start, input)?);
     }
     Ok(pipeline)
@@ -73,17 +79,31 @@ pub fn parse(input: &Input) -> Result<Pipeline, ShellError> {
 ///
 /// `abs_start` is the byte offset of `buffer[0]` within the raw input line,
 /// used to anchor all diagnostic spans to the original string.
-fn parse_segment(buffer: &[u8], abs_start: usize, input: &Input) -> Result<PipelineStage, ShellError> {
-    let (command, raw_args) = split_command_and_args(buffer, abs_start, input)?;
-    let command = parse_command(&command);
+fn parse_segment(
+    buffer: &[u8],
+    abs_start: usize,
+    input: &Input,
+) -> Result<PipelineStage, ShellError> {
+    let (command_bytes, command_span, raw_args) = split_command_and_args(buffer, abs_start, input)?;
+    let src = input.as_source();
+    let command = parse_command(&command_bytes, command_span, src.clone());
 
     let (args, stdout_redirect, stderr_redirect) = extract_redirects(raw_args);
 
     let args = args
         .into_iter()
-        .map(|(bytes, style)| match style {
-            QuoteStyle::None => Arg::Literal(bytes),
-            style => Arg::Quoted { bytes, style },
+        .map(|(bytes, style, span)| match style {
+            QuoteStyle::None => Arg::Literal {
+                bytes,
+                span,
+                src: src.clone(),
+            },
+            style => Arg::Quoted {
+                bytes,
+                style,
+                span,
+                src: src.clone(),
+            },
         })
         .collect();
     Ok((command, args, stdout_redirect, stderr_redirect))
@@ -130,12 +150,16 @@ fn split_pipeline_segments(buffer: &[u8]) -> Vec<&[u8]> {
     segments
 }
 
-/// Raw argument token: byte content and its quoting style.
-type RawArg = (Vec<u8>, QuoteStyle);
+/// Raw argument token: byte content, quoting style, and absolute source span.
+type RawArg = (Vec<u8>, QuoteStyle, SourceSpan);
 
 /// Result of redirect extraction: remaining args, optional stdout [`StdoutRedirection`],
 /// and optional stderr [`StderrRedirection`].
-type ExtractResult = (Vec<RawArg>, Option<StdoutRedirection>, Option<StderrRedirection>);
+type ExtractResult = (
+    Vec<RawArg>,
+    Option<StdoutRedirection>,
+    Option<StderrRedirection>,
+);
 
 /// Scan `raw_args` for unquoted redirect operators
 /// (`>`, `1>`, `>>`, `1>>`, `2>`, `2>>`).
@@ -160,7 +184,7 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
     let mut stderr_redirect: Option<StderrRedirection> = None;
 
     let mut iter = raw_args.into_iter().peekable();
-    while let Some((bytes, style)) = iter.next() {
+    while let Some((bytes, style, span)) = iter.next() {
         // Only treat unquoted tokens as potential redirect operators.
         if style == QuoteStyle::None {
             let token = &bytes[..];
@@ -180,10 +204,9 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
             };
 
             if let Some((is_stdout, mode)) = op {
-                if let Some((target_bytes, _)) = iter.next() {
-                    let target = std::path::PathBuf::from(
-                        String::from_utf8_lossy(&target_bytes).as_ref(),
-                    );
+                if let Some((target_bytes, _, _)) = iter.next() {
+                    let target =
+                        std::path::PathBuf::from(String::from_utf8_lossy(&target_bytes).as_ref());
                     if is_stdout {
                         stdout_redirect = Some(StdoutRedirection::new(mode, target));
                     } else {
@@ -192,12 +215,12 @@ fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
                 } else {
                     // No filename follows the operator — keep it as a literal
                     // argument rather than silently dropping it.
-                    out_args.push((bytes, style));
+                    out_args.push((bytes, style, span));
                 }
                 continue;
             }
         }
-        out_args.push((bytes, style));
+        out_args.push((bytes, style, span));
     }
 
     (out_args, stdout_redirect, stderr_redirect)
@@ -223,19 +246,23 @@ fn split_command_and_args(
     buffer: &[u8],
     abs_start: usize,
     input: &Input,
-) -> Result<(Vec<u8>, Vec<RawArg>), ShellError> {
-    let mut parts: Vec<(Vec<u8>, QuoteStyle)> = Vec::new();
+) -> Result<(Vec<u8>, SourceSpan, Vec<RawArg>), ShellError> {
+    let mut parts: Vec<(Vec<u8>, QuoteStyle, SourceSpan)> = Vec::new();
 
     let mut current: Vec<u8> = Vec::new();
     let mut in_single_quote = false;
     let mut in_double_quote = false;
     let mut token_started = false;
     let mut token_style: Option<QuoteStyle> = None;
+    // Absolute byte offset of the first byte of the current token (set when token_started
+    // transitions false → true).
+    let mut token_start_abs: usize = 0;
     // Absolute byte offset of the opening quote character within the raw input.
     let mut quote_open_pos: usize = 0;
 
     let mut i = 0;
     while i < buffer.len() {
+        let iter_start_i = i;
         let byte = buffer[i];
 
         if in_single_quote {
@@ -267,6 +294,9 @@ fn split_command_and_args(
                 i += 1;
                 current.push(buffer[i]);
             }
+            if !token_started {
+                token_start_abs = abs_start + iter_start_i;
+            }
             token_started = true;
             token_style = match token_style {
                 None | Some(QuoteStyle::None) => Some(QuoteStyle::None),
@@ -275,6 +305,9 @@ fn split_command_and_args(
         } else if byte == b'\'' {
             in_single_quote = true;
             quote_open_pos = abs_start + i;
+            if !token_started {
+                token_start_abs = abs_start + iter_start_i;
+            }
             token_started = true;
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Single);
@@ -284,6 +317,9 @@ fn split_command_and_args(
         } else if byte == b'"' {
             in_double_quote = true;
             quote_open_pos = abs_start + i;
+            if !token_started {
+                token_start_abs = abs_start + iter_start_i;
+            }
             token_started = true;
             if token_style.is_none() {
                 token_style = Some(QuoteStyle::Double);
@@ -293,10 +329,15 @@ fn split_command_and_args(
         } else if byte.is_ascii_whitespace() {
             if token_started || !current.is_empty() {
                 let style = token_style.take().unwrap_or(QuoteStyle::None);
-                parts.push((std::mem::take(&mut current), style));
+                let span =
+                    SourceSpan::from((token_start_abs, abs_start + iter_start_i - token_start_abs));
+                parts.push((std::mem::take(&mut current), style, span));
                 token_started = false;
             }
         } else {
+            if !token_started {
+                token_start_abs = abs_start + iter_start_i;
+            }
             current.push(byte);
             token_started = true;
             token_style = match token_style {
@@ -325,27 +366,36 @@ fn split_command_and_args(
 
     if token_started || !current.is_empty() {
         let style = token_style.unwrap_or(QuoteStyle::None);
-        parts.push((current, style));
+        let span = SourceSpan::from((token_start_abs, abs_start + buffer.len() - token_start_abs));
+        parts.push((current, style, span));
     }
 
     if parts.is_empty() {
-        return Ok((Vec::new(), Vec::new()));
+        return Ok((Vec::new(), SourceSpan::from((abs_start, 0)), Vec::new()));
     }
 
     let mut iter = parts.into_iter();
-    let (command, _) = iter.next().unwrap_or((Vec::new(), QuoteStyle::None));
-    let args: Vec<(Vec<u8>, QuoteStyle)> = iter.collect();
+    let (command, _, cmd_span) = iter.next().unwrap_or((
+        Vec::new(),
+        QuoteStyle::None,
+        SourceSpan::from((abs_start, 0)),
+    ));
+    let args: Vec<RawArg> = iter.collect();
 
-    Ok((command, args))
+    Ok((command, cmd_span, args))
 }
 
 /// Resolve a raw command token to a [`Command`] variant.
-pub fn parse_command(command: &[u8]) -> Command {
-    if !command.is_ascii() {
-        return Command::Unrecognized(command.into());
+pub fn parse_command(bytes: &[u8], span: SourceSpan, src: InputSource) -> Command {
+    if !bytes.is_ascii() {
+        return Command::Unrecognized {
+            bytes: bytes.to_vec(),
+            span,
+            src,
+        };
     }
 
-    let command = std::str::from_utf8(command).expect("checked ASCII above");
+    let command = std::str::from_utf8(bytes).expect("checked ASCII above");
 
     let name = builtin::BuiltInName::from_str(command);
     if let Ok(name) = name {
@@ -359,13 +409,17 @@ pub fn parse_command(command: &[u8]) -> Command {
             }
         }
 
-        Command::Unrecognized(command.into())
+        Command::Unrecognized {
+            bytes: bytes.to_vec(),
+            span,
+            src,
+        }
     }
 }
 
 /// Parse a raw byte slice into an [`Arg`].
 pub fn parse_arg(arg: &[u8]) -> Arg {
-    Arg::Literal(arg.to_vec())
+    Arg::synthetic(arg)
 }
 
 #[cfg(test)]
@@ -379,15 +433,17 @@ mod tests {
     // Helper: split and return command + arg bytes (quoting metadata stripped).
     fn split(input: &[u8]) -> (Vec<u8>, Vec<Vec<u8>>) {
         let src = Input::new(input);
-        let (cmd, args) = split_command_and_args(input, 0, &src).unwrap();
-        let arg_bytes = args.into_iter().map(|(b, _)| b).collect();
+        let (cmd, _, args) = split_command_and_args(input, 0, &src).unwrap();
+        let arg_bytes = args.into_iter().map(|(b, _, _)| b).collect();
         (cmd, arg_bytes)
     }
 
     // Helper: split and return command + (bytes, style) pairs.
     fn split_styled(input: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>) {
         let src = Input::new(input);
-        split_command_and_args(input, 0, &src).unwrap()
+        let (cmd, _, args) = split_command_and_args(input, 0, &src).unwrap();
+        let styled = args.into_iter().map(|(b, s, _)| (b, s)).collect();
+        (cmd, styled)
     }
 
     #[test]
@@ -399,21 +455,23 @@ mod tests {
 
     #[test]
     fn test_parse_command_empty() {
-        let command = "".as_bytes();
-        let command = parse_command(command);
+        let command = parse_command(b"", SourceSpan::from((0, 0)), InputSource::synthetic());
         match command {
-            Command::Unrecognized(command) => assert_eq!(command.len(), 0),
+            Command::Unrecognized { bytes, .. } => assert_eq!(bytes.len(), 0),
             _ => panic!("Empty command unexpectedly found as: {}", command),
         }
     }
 
     #[test]
     fn test_parse_command_unrecognized() {
-        let command = "some_non_existent_command".as_bytes();
-        let command = parse_command(command);
+        let command = parse_command(
+            b"some_non_existent_command",
+            SourceSpan::from((0, 0)),
+            InputSource::synthetic(),
+        );
         match command {
-            Command::Unrecognized(cmd) => {
-                assert_eq!(cmd, b"some_non_existent_command");
+            Command::Unrecognized { bytes, .. } => {
+                assert_eq!(bytes, b"some_non_existent_command");
             }
             _ => panic!("Unrecognized command was recognized: {}", command),
         }
@@ -424,7 +482,7 @@ mod tests {
         let arg = "/home/user".as_bytes();
         let parsed_arg = parse_arg(arg);
         assert_eq!(parsed_arg.as_bytes(), arg);
-        assert!(matches!(parsed_arg, Arg::Literal(_)));
+        assert!(matches!(parsed_arg, Arg::Literal { .. }));
     }
 
     #[test]
@@ -456,7 +514,7 @@ mod tests {
         let arg = "".as_bytes();
         let parsed_arg = parse_arg(arg);
         assert!(parsed_arg.as_bytes().is_empty());
-        assert!(matches!(parsed_arg, Arg::Literal(_)));
+        assert!(matches!(parsed_arg, Arg::Literal { .. }));
     }
 
     #[test]
@@ -464,7 +522,7 @@ mod tests {
         let arg = "file-with_special.chars".as_bytes();
         let parsed_arg = parse_arg(arg);
         assert_eq!(parsed_arg.as_bytes(), arg);
-        assert!(matches!(parsed_arg, Arg::Literal(_)));
+        assert!(matches!(parsed_arg, Arg::Literal { .. }));
     }
 
     // --- Double-quote tests ---
@@ -675,7 +733,13 @@ mod tests {
         let result = split_command_and_args(buf, 0, &src);
         let err = result.unwrap_err();
         assert!(
-            matches!(err, ShellError::UnclosedQuote { style: QuoteStyle::Double, .. }),
+            matches!(
+                err,
+                ShellError::UnclosedQuote {
+                    style: QuoteStyle::Double,
+                    ..
+                }
+            ),
             "expected UnclosedQuote(Double), got: {err:?}"
         );
     }
@@ -699,7 +763,13 @@ mod tests {
         let result = split_command_and_args(buf, 0, &src);
         let err = result.unwrap_err();
         assert!(
-            matches!(err, ShellError::UnclosedQuote { style: QuoteStyle::Single, .. }),
+            matches!(
+                err,
+                ShellError::UnclosedQuote {
+                    style: QuoteStyle::Single,
+                    ..
+                }
+            ),
             "expected UnclosedQuote(Single), got: {err:?}"
         );
     }
@@ -733,7 +803,11 @@ mod tests {
         let input = Input::new(raw);
         let err = parse(&input).unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
-            assert_eq!(span.offset(), 16, "quote `\"` is at byte 16 in the full input");
+            assert_eq!(
+                span.offset(),
+                16,
+                "quote `\"` is at byte 16 in the full input"
+            );
         } else {
             panic!("expected UnclosedQuote, got: {err:?}");
         }
@@ -751,8 +825,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello > out.txt");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello > out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -765,8 +838,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello 1> out.txt");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 1> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -779,8 +851,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello >> out.txt");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello >> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -793,8 +864,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_1gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello 1>> out.txt");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 1>> out.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
@@ -807,13 +877,15 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_2gt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello 2> err.txt");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 2> err.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello"]
         );
-        assert!(stdout_redirect.is_none(), "stdout redirect should be None for 2>");
+        assert!(
+            stdout_redirect.is_none(),
+            "stdout redirect should be None for 2>"
+        );
         let r = stderr_redirect.expect("stderr redirect should be Some for 2>");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("err.txt"));
@@ -835,8 +907,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_last_wins_stdout() {
-        let (_, args, stdout_redirect, _) =
-            parse_single(b"echo hi > first.txt >> last.txt");
+        let (_, args, stdout_redirect, _) = parse_single(b"echo hi > first.txt >> last.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hi"]
@@ -848,8 +919,7 @@ mod tests {
 
     #[test]
     fn test_parse_redirect_last_wins_stderr() {
-        let (_, args, _, stderr_redirect) =
-            parse_single(b"echo hi 2> first.txt 2>> last.txt");
+        let (_, args, _, stderr_redirect) = parse_single(b"echo hi 2> first.txt 2>> last.txt");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hi"]
@@ -862,7 +932,10 @@ mod tests {
     #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
         let (_, args, stdout_redirect, _) = parse_single(b"echo >");
-        assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
+        assert!(
+            stdout_redirect.is_none(),
+            "no redirect target means no Redirection"
+        );
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec![">"],
@@ -873,7 +946,10 @@ mod tests {
     #[test]
     fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
         let (_, args, stdout_redirect, _) = parse_single(b"echo >>");
-        assert!(stdout_redirect.is_none(), "no redirect target means no Redirection");
+        assert!(
+            stdout_redirect.is_none(),
+            "no redirect target means no Redirection"
+        );
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec![">>"],
@@ -884,7 +960,10 @@ mod tests {
     #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
         let (_, args, _, stderr_redirect) = parse_single(b"echo 2>");
-        assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
+        assert!(
+            stderr_redirect.is_none(),
+            "no redirect target means no Redirection"
+        );
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["2>"],
@@ -909,7 +988,10 @@ mod tests {
     #[test]
     fn test_parse_stderr_append_redirect_trailing_operator_kept_as_arg() {
         let (_, args, _, stderr_redirect) = parse_single(b"echo 2>>");
-        assert!(stderr_redirect.is_none(), "no redirect target means no Redirection");
+        assert!(
+            stderr_redirect.is_none(),
+            "no redirect target means no Redirection"
+        );
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["2>>"],
@@ -919,8 +1001,7 @@ mod tests {
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"echo hello world");
+        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello world");
         assert_eq!(
             args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
             vec!["hello", "world"]
@@ -979,7 +1060,9 @@ mod tests {
         let p = parse_raw(b"echo foo | cat > out.txt").unwrap();
         assert_eq!(p.len(), 2);
         let (_, _, stdout_redir, _) = &p[1];
-        let r = stdout_redir.as_ref().expect("last stage should have redirect");
+        let r = stdout_redir
+            .as_ref()
+            .expect("last stage should have redirect");
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
     }
 
@@ -1041,7 +1124,11 @@ mod tests {
         // "echo a | | cat" — second `|` is at byte 9
         let err = parse_raw(b"echo a | | cat").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
-            assert_eq!(span.offset(), 9, "second `|` is at byte 9 in 'echo a | | cat'");
+            assert_eq!(
+                span.offset(),
+                9,
+                "second `|` is at byte 9 in 'echo a | | cat'"
+            );
             assert_eq!(span.len(), 1);
         } else {
             panic!("expected EmptyPipelineSegment");
@@ -1062,7 +1149,11 @@ mod tests {
         // "echo a |   | cat" — second `|` is at byte 11
         let err = parse_raw(b"echo a |   | cat").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
-            assert_eq!(span.offset(), 11, "second `|` is at byte 11 in 'echo a |   | cat'");
+            assert_eq!(
+                span.offset(),
+                11,
+                "second `|` is at byte 11 in 'echo a |   | cat'"
+            );
         } else {
             panic!("expected EmptyPipelineSegment");
         }
@@ -1077,6 +1168,9 @@ mod tests {
     #[test]
     fn test_empty_pipeline_segment_display() {
         let err = parse_raw(b"| cat").unwrap_err();
-        assert!(err.to_string().contains("|"), "expected `|` in error message, got: {err}");
+        assert!(
+            err.to_string().contains("|"),
+            "expected `|` in error message, got: {err}"
+        );
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -65,8 +65,7 @@ impl Shell {
                 Ok(None) => {}
                 Err(e) => {
                     let fatal = e.is_fatal();
-                    let report = miette::Report::new(e).with_source_code(input.as_source());
-                    writeln!(err, "{report:?}").into_diagnostic()?;
+                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
                     if fatal {
                         return Ok(ExitCode::FAILURE);
                     }

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -31,7 +31,9 @@ fn echo_with_no_arguments() {
 
 #[test]
 fn echo_with_single_argument() {
-    ShellHarness::new().run("echo hello").assert_stdout_contains("hello");
+    ShellHarness::new()
+        .run("echo hello")
+        .assert_stdout_contains("hello");
 }
 
 #[test]
@@ -114,6 +116,24 @@ fn cd_relative_then_back() {
         .run("cd subdir\ncd ..\npwd\necho done")
         .assert_stdout_contains("done")
         .assert_stderr_empty();
+}
+
+#[test]
+fn cd_no_args_without_home_shows_error() {
+    ShellHarness::new()
+        .without_home()
+        .run("cd\necho survived")
+        .assert_stderr_contains("home directory not set")
+        .assert_stdout_contains("survived");
+}
+
+#[test]
+fn cd_tilde_without_home_shows_error() {
+    ShellHarness::new()
+        .without_home()
+        .run("cd ~\necho survived")
+        .assert_stderr_contains("home directory not set")
+        .assert_stdout_contains("survived");
 }
 
 // ============================================================================

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,6 +13,7 @@ pub struct ShellHarness {
     temp_dir: tempfile::TempDir,
     setup_dirs: Vec<String>,
     setup_files: Vec<(String, String)>,
+    no_home: bool,
 }
 
 impl Default for ShellHarness {
@@ -27,7 +28,14 @@ impl ShellHarness {
             temp_dir: tempfile::tempdir().expect("create temp dir"),
             setup_dirs: Vec::new(),
             setup_files: Vec::new(),
+            no_home: false,
         }
+    }
+
+    /// Run without HOME set (and without USERPROFILE on Windows).
+    pub fn without_home(mut self) -> Self {
+        self.no_home = true;
+        self
     }
 
     /// Pre-create a directory relative to the isolated home before running.
@@ -38,7 +46,8 @@ impl ShellHarness {
 
     /// Pre-create a file with the given contents relative to the isolated home.
     pub fn with_file(mut self, path: &str, contents: &str) -> Self {
-        self.setup_files.push((path.to_string(), contents.to_string()));
+        self.setup_files
+            .push((path.to_string(), contents.to_string()));
         self
     }
 
@@ -65,17 +74,27 @@ impl ShellHarness {
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .env("HOME", &home)
             .current_dir(&home);
 
-        // On Windows the home directory comes from USERPROFILE / HOMEDRIVE+HOMEPATH.
-        #[cfg(windows)]
-        {
-            cmd.env("USERPROFILE", &home);
-            if let Some(s) = home.to_str() {
-                if let Some((drive, path)) = s.split_once(':') {
-                    cmd.env("HOMEDRIVE", format!("{drive}:"));
-                    cmd.env("HOMEPATH", if path.is_empty() { "\\" } else { path });
+        if self.no_home {
+            cmd.env_remove("HOME");
+            #[cfg(windows)]
+            {
+                cmd.env_remove("USERPROFILE");
+                cmd.env_remove("HOMEDRIVE");
+                cmd.env_remove("HOMEPATH");
+            }
+        } else {
+            cmd.env("HOME", &home);
+            // On Windows the home directory comes from USERPROFILE / HOMEDRIVE+HOMEPATH.
+            #[cfg(windows)]
+            {
+                cmd.env("USERPROFILE", &home);
+                if let Some(s) = home.to_str() {
+                    if let Some((drive, path)) = s.split_once(':') {
+                        cmd.env("HOMEDRIVE", format!("{drive}:"));
+                        cmd.env("HOMEPATH", if path.is_empty() { "\\" } else { path });
+                    }
                 }
             }
         }
@@ -144,7 +163,8 @@ impl ShellOutput {
         assert!(
             self.stdout.contains(s),
             "expected stdout to contain {s:?}\nstdout:\n{}\nstderr:\n{}",
-            self.stdout, self.stderr,
+            self.stdout,
+            self.stderr,
         );
         self
     }
@@ -161,7 +181,11 @@ impl ShellOutput {
 
     #[track_caller]
     pub fn assert_stdout_empty(&self) -> &Self {
-        assert!(self.stdout.is_empty(), "expected stdout to be empty\nstdout:\n{}", self.stdout);
+        assert!(
+            self.stdout.is_empty(),
+            "expected stdout to be empty\nstdout:\n{}",
+            self.stdout
+        );
         self
     }
 
@@ -170,7 +194,8 @@ impl ShellOutput {
         assert!(
             self.stderr.contains(s),
             "expected stderr to contain {s:?}\nstderr:\n{}\nstdout:\n{}",
-            self.stderr, self.stdout,
+            self.stderr,
+            self.stdout,
         );
         self
     }
@@ -187,7 +212,11 @@ impl ShellOutput {
 
     #[track_caller]
     pub fn assert_stderr_empty(&self) -> &Self {
-        assert!(self.stderr.is_empty(), "expected stderr to be empty\nstderr:\n{}", self.stderr);
+        assert!(
+            self.stderr.is_empty(),
+            "expected stderr to be empty\nstderr:\n{}",
+            self.stderr
+        );
         self
     }
 


### PR DESCRIPTION
Extends the self-contained miette diagnostic pattern from parse errors to executor errors. Every `Arg` and `Command::Unrecognized` token now carries `span: SourceSpan` and `src: InputSource` stamped at parse time, so `CommandNotFound`, `FileNotFound`, and `NotADirectory` emit fully self-contained diagnostics without threading `Input` through the executor or attaching source context in `shell.rs`.

Key changes:
- `Arg` gains struct variants with `span + src`; `Arg::synthetic(&[u8])` replaces the removed `From` impls for zero-context construction
- `Command::Unrecognized` becomes a struct variant with `span + src`
- Parser tracks token start positions and stamps every token at parse time
- `execute_cd` handles the no-arg case directly via `ctx.home_dir`; new `HomeNotSet` error for missing HOME
- `shell.rs` no longer need `.with_source_code()` on executor errors

Closes #111