### PR TITLE
feat: split parser into lexer/parser/resolver pipeline stages

### DIFF
--- a/src/arg.rs
+++ b/src/arg.rs
@@ -31,7 +31,9 @@ impl Arg {
     /// Use only in tests or for arguments not derived from user input.
     pub fn synthetic(bytes: &[u8]) -> Self {
         let b = Bytes::copy_from_slice(bytes);
-        let span = SourceSpan::from((0_usize, bytes.len()));
+        // Zero-length span: synthetic source has no bytes, so any non-zero span would be
+        // out-of-bounds if miette ever tries to render it.
+        let span = SourceSpan::from((0_usize, 0_usize));
         let src = InputSource::synthetic();
         Arg {
             tokens: vec![Token {

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -1,112 +1,69 @@
 use std::path::PathBuf;
 
+use bytes::Bytes;
 use miette::SourceSpan;
 
 use crate::input::InputSource;
+use crate::lexer::{Token, TokenKind};
 
 /// A list of shell command arguments.
 pub type Args = Vec<Arg>;
 
-/// The quoting context in which a shell argument was parsed.
-///
-/// Tracks whether the argument originated from a single-quoted string, a
-/// double-quoted string, an entirely unquoted token, or a mixed-quoting
-/// context.  This is used by future features: globbing is suppressed for all
-/// quoted args; variable expansion is suppressed for single-quoted args;
-/// operator detection (e.g. redirects) is restricted to [`QuoteStyle::None`]-style tokens.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QuoteStyle {
-    /// Argument was entirely unquoted — no quote characters were present.
-    None,
-    /// Argument combined quoted and unquoted segments (e.g. `pre"mid"post`, `1'>'`).
-    Mixed,
-    /// Argument was entirely enclosed in single quotes; all characters are literal.
-    Single,
-    /// Argument was entirely enclosed in double quotes; backslash escaping applies.
-    Double,
-}
-
 /// Represents a shell command argument produced by the parser.
 ///
-/// Every `Arg` carries the byte offset and source of the token as it appeared
-/// in the original input line, so executor errors can embed self-contained
-/// diagnostic labels without any additional context threading.
+/// Every `Arg` carries the source tokens, combined byte content, absolute span,
+/// and input source, enabling precise diagnostics without any extra context threading.
 #[derive(Debug, Clone)]
-pub enum Arg {
-    /// An unquoted token.
-    Literal {
-        /// The parsed byte content.
-        bytes: Vec<u8>,
-        /// Byte offset and length of this token in the raw input line.
-        span: SourceSpan,
-        /// The raw input line this token was parsed from.
-        src: InputSource,
-    },
-    /// A token whose quoting origin is preserved.
-    Quoted {
-        /// The parsed byte content (quotes stripped, escapes resolved).
-        bytes: Vec<u8>,
-        /// The quoting context in which this argument was parsed.
-        style: QuoteStyle,
-        /// Byte offset and length of this token in the raw input line.
-        span: SourceSpan,
-        /// The raw input line this token was parsed from.
-        src: InputSource,
-    },
+pub struct Arg {
+    /// The constituent lexer tokens that make up this argument.
+    pub tokens: Vec<Token>,
+    /// Combined byte content of all tokens (quotes stripped, escapes resolved).
+    pub bytes: Bytes,
+    /// Byte offset and length spanning from the first to the last token in the raw input.
+    pub span: SourceSpan,
+    /// The raw input line this argument was parsed from.
+    pub src: InputSource,
 }
 
 impl Arg {
-    /// Construct a synthetic argument with no source location.
+    /// Construct a synthetic argument with no real source location.
     ///
-    /// Use only in tests or for arguments that are not derived from user input.
+    /// Use only in tests or for arguments not derived from user input.
     pub fn synthetic(bytes: &[u8]) -> Self {
-        Arg::Literal {
-            bytes: bytes.to_vec(),
-            span: SourceSpan::from((0, 0)),
-            src: InputSource::synthetic(),
+        let b = Bytes::copy_from_slice(bytes);
+        let span = SourceSpan::from((0_usize, bytes.len()));
+        let src = InputSource::synthetic();
+        Arg {
+            tokens: vec![Token {
+                kind: TokenKind::Word(b.clone()),
+                span,
+                src: src.clone(),
+            }],
+            bytes: b,
+            span,
+            src,
         }
     }
 
-    /// The parsed byte content of this argument.
+    /// The combined byte content of this argument.
     pub fn as_bytes(&self) -> &[u8] {
-        match self {
-            Arg::Literal { bytes, .. } | Arg::Quoted { bytes, .. } => bytes,
-        }
+        &self.bytes
     }
 
-    /// Byte offset and length of this token in the raw input line.
+    /// Byte offset and length of this argument in the raw input.
     pub fn span(&self) -> SourceSpan {
-        match self {
-            Arg::Literal { span, .. } | Arg::Quoted { span, .. } => *span,
-        }
+        self.span
     }
 
-    /// The raw input source this token was parsed from.
+    /// The raw input source this argument was parsed from.
     pub fn src(&self) -> InputSource {
-        match self {
-            Arg::Literal { src, .. } | Arg::Quoted { src, .. } => src.clone(),
-        }
+        self.src.clone()
     }
 }
 
 impl PartialEq for Arg {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Arg::Literal { bytes: a, .. }, Arg::Literal { bytes: b, .. }) => a == b,
-            (
-                Arg::Quoted {
-                    bytes: a,
-                    style: sa,
-                    ..
-                },
-                Arg::Quoted {
-                    bytes: b,
-                    style: sb,
-                    ..
-                },
-            ) => a == b && sa == sb,
-            _ => false,
-        }
+        self.bytes == other.bytes
     }
 }
 
@@ -114,7 +71,7 @@ impl Eq for Arg {}
 
 impl std::fmt::Display for Arg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", String::from_utf8_lossy(self.as_bytes()))
+        write!(f, "{}", String::from_utf8_lossy(&self.bytes))
     }
 }
 
@@ -132,7 +89,8 @@ mod tests {
     fn synthetic_as_bytes() {
         let arg = Arg::synthetic(b"hello");
         assert_eq!(arg.as_bytes(), b"hello");
-        assert!(matches!(arg, Arg::Literal { .. }));
+        assert_eq!(arg.tokens.len(), 1);
+        assert!(matches!(arg.tokens[0].kind, TokenKind::Word(_)));
     }
 
     #[test]
@@ -153,17 +111,5 @@ mod tests {
         let arg = Arg::synthetic(b"/path/to/file");
         let pathbuf = PathBuf::from(&arg);
         assert_eq!(pathbuf, PathBuf::from("/path/to/file"));
-    }
-
-    #[test]
-    fn quoted_as_bytes() {
-        let arg = Arg::Quoted {
-            bytes: b"hello world".to_vec(),
-            style: QuoteStyle::Single,
-            span: SourceSpan::from((0, 13)),
-            src: InputSource::synthetic(),
-        };
-        assert_eq!(arg.as_bytes(), b"hello world");
-        assert_eq!(arg.to_string(), "hello world");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ pub struct Cli {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::{CommandFactory, error::ErrorKind};
+    use clap::{error::ErrorKind, CommandFactory};
 
     #[test]
     fn cli_debug_assert() {

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,53 +1,34 @@
 use std::fmt::Display;
 
-use miette::SourceSpan;
-
-use crate::input::InputSource;
-
 pub(crate) mod builtin;
 pub(crate) mod executable;
 
-/// Represents a shell command.
+/// The kind of a resolved shell command.
 #[derive(Debug, Clone)]
-pub enum Command {
+pub enum CommandKind {
     /// A shell built-in command (e.g. `echo`, `cd`, `exit`).
     BuiltIn(builtin::BuiltInCommand),
     /// An external executable found on `PATH`.
     Executable(executable::ExecutableCommand),
-    /// A command token that could not be resolved to a built-in or executable.
-    Unrecognized {
-        /// The raw bytes of the unrecognized command token.
-        bytes: Vec<u8>,
-        /// Byte offset and length of this token in the raw input line.
-        span: SourceSpan,
-        /// The raw input line this token was parsed from.
-        src: InputSource,
-    },
 }
 
-impl PartialEq for Command {
+impl PartialEq for CommandKind {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Command::BuiltIn(a), Command::BuiltIn(b)) => a == b,
-            (Command::Executable(a), Command::Executable(b)) => a == b,
-            (Command::Unrecognized { bytes: a, .. }, Command::Unrecognized { bytes: b, .. }) => {
-                a == b
-            }
+            (CommandKind::BuiltIn(a), CommandKind::BuiltIn(b)) => a == b,
+            (CommandKind::Executable(a), CommandKind::Executable(b)) => a == b,
             _ => false,
         }
     }
 }
 
-impl Eq for Command {}
+impl Eq for CommandKind {}
 
-impl Display for Command {
+impl Display for CommandKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Command::BuiltIn(builtin) => write!(f, "{}", builtin),
-            Command::Executable(executable) => write!(f, "{}", executable),
-            Command::Unrecognized { bytes, .. } => {
-                write!(f, "{}", String::from_utf8_lossy(bytes))
-            }
+            CommandKind::BuiltIn(builtin) => write!(f, "{}", builtin),
+            CommandKind::Executable(executable) => write!(f, "{}", executable),
         }
     }
 }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -37,12 +37,20 @@ pub struct ShellCtx {
 impl ShellCtx {
     /// Create a new context with default configuration.
     pub fn new(home_dir: Option<PathBuf>, cwd: PathBuf) -> Self {
-        Self { home_dir, cwd, config: ShellConfig::default() }
+        Self {
+            home_dir,
+            cwd,
+            config: ShellConfig::default(),
+        }
     }
 
     /// Create a new context with explicit configuration.
     pub fn with_config(home_dir: Option<PathBuf>, cwd: PathBuf, config: ShellConfig) -> Self {
-        Self { home_dir, cwd, config }
+        Self {
+            home_dir,
+            cwd,
+            config,
+        }
     }
 
     /// Initialize from the current process environment.

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, io, path::PathBuf};
+use std::{env, io, path::PathBuf};
 
 /// Return the current user's home directory, if it can be determined from the environment.
 pub fn home_dir() -> Option<PathBuf> {
@@ -34,17 +34,6 @@ pub fn current_dir() -> Result<PathBuf, io::Error> {
 /// Change the current working directory of the process to `path`.
 pub fn set_current_dir(path: &PathBuf) -> io::Result<()> {
     env::set_current_dir(path)
-}
-
-pub(crate) fn get_path_files() -> impl Iterator<Item = PathBuf> {
-    get_path_dirs().flat_map(|d| {
-        fs::read_dir(d)
-            .ok()
-            .into_iter()
-            .flatten()
-            .filter_map(|entry| entry.ok().map(|e| e.path()))
-            .collect::<Vec<_>>()
-    })
 }
 
 pub(crate) fn get_path_dirs() -> impl Iterator<Item = PathBuf> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use std::process::ExitStatus;
 
-use crate::arg::QuoteStyle;
-use crate::command::Command;
+use crate::command::CommandKind;
 use crate::input::InputSource;
+use crate::lexer::QuoteKind;
 use miette::{Diagnostic, SourceSpan};
 use thiserror::Error;
 
@@ -102,7 +102,7 @@ pub enum ShellError {
     #[diagnostic(code(ferrish::exec::command_error))]
     InCommand {
         /// The command that was executing when the error occurred.
-        command: Command,
+        command: CommandKind,
         /// The underlying shell error.
         #[source]
         #[diagnostic_source]
@@ -117,14 +117,14 @@ pub enum ShellError {
 
     // --- Parse ---
     /// An opening quote was never closed before end of input.
-    #[error("unclosed {style:?} quote")]
+    #[error("unclosed {style} quote")]
     #[diagnostic(
         code(ferrish::parse::unclosed_quote),
         help("add the matching quote to close this token")
     )]
     UnclosedQuote {
         /// The kind of quote that was opened but never closed.
-        style: QuoteStyle,
+        style: QuoteKind,
         /// Absolute byte offset of the opening quote character in the raw input line.
         #[label("quote opened here")]
         span: SourceSpan,
@@ -298,7 +298,7 @@ mod tests {
             src: dummy_src(),
         };
         let err = ShellError::InCommand {
-            command: Command::BuiltIn(crate::command::builtin::BuiltInCommand::new(
+            command: CommandKind::BuiltIn(crate::command::builtin::BuiltInCommand::new(
                 crate::command::builtin::BuiltInName::Cd,
             )),
             source: Box::new(inner),
@@ -310,11 +310,9 @@ mod tests {
     fn test_in_command_fatal_delegates_to_source() {
         let inner = ShellError::ExecutionFailed(std::io::Error::last_os_error());
         let err = ShellError::InCommand {
-            command: Command::Unrecognized {
-                bytes: b"mycmd".to_vec(),
-                span: dummy_span(),
-                src: dummy_src(),
-            },
+            command: CommandKind::BuiltIn(crate::command::builtin::BuiltInCommand::new(
+                crate::command::builtin::BuiltInName::Echo,
+            )),
             source: Box::new(inner),
         };
         assert!(err.is_fatal());
@@ -323,21 +321,21 @@ mod tests {
     #[test]
     fn test_display_unclosed_quote_single() {
         let err = ShellError::UnclosedQuote {
-            style: QuoteStyle::Single,
+            style: QuoteKind::Single,
             span: SourceSpan::from((0, 1)),
             src: dummy_src(),
         };
-        assert_eq!(err.to_string(), "unclosed Single quote");
+        assert_eq!(err.to_string(), "unclosed single quote");
     }
 
     #[test]
     fn test_display_unclosed_quote_double() {
         let err = ShellError::UnclosedQuote {
-            style: QuoteStyle::Double,
+            style: QuoteKind::Double,
             span: SourceSpan::from((5, 1)),
             src: dummy_src(),
         };
-        assert_eq!(err.to_string(), "unclosed Double quote");
+        assert_eq!(err.to_string(), "unclosed double quote");
     }
 
     #[cfg(unix)]
@@ -356,11 +354,9 @@ mod tests {
         let status = ExitStatus::from_raw(2 << 8);
         let inner = ShellError::NonZeroExit(status);
         let err = ShellError::InCommand {
-            command: Command::Unrecognized {
-                bytes: b"foo".to_vec(),
-                span: dummy_span(),
-                src: dummy_src(),
-            },
+            command: CommandKind::BuiltIn(crate::command::builtin::BuiltInCommand::new(
+                crate::command::builtin::BuiltInName::Echo,
+            )),
             source: Box::new(inner),
         };
         assert_eq!(err.as_exit_status(), Some(status));
@@ -405,7 +401,7 @@ mod tests {
     #[test]
     fn test_is_fatal_unclosed_quote() {
         let err = ShellError::UnclosedQuote {
-            style: QuoteStyle::Double,
+            style: QuoteKind::Double,
             span: SourceSpan::from((0, 1)),
             src: dummy_src(),
         };
@@ -485,12 +481,12 @@ mod tests {
     #[test]
     fn test_equality_unclosed_quote() {
         let e1 = ShellError::UnclosedQuote {
-            style: QuoteStyle::Single,
+            style: QuoteKind::Single,
             span: SourceSpan::from((3, 1)),
             src: dummy_src(),
         };
         let e2 = ShellError::UnclosedQuote {
-            style: QuoteStyle::Single,
+            style: QuoteKind::Single,
             span: SourceSpan::from((3, 1)),
             src: dummy_src(),
         };
@@ -500,12 +496,12 @@ mod tests {
     #[test]
     fn test_inequality_unclosed_quote_different_style() {
         let e1 = ShellError::UnclosedQuote {
-            style: QuoteStyle::Single,
+            style: QuoteKind::Single,
             span: SourceSpan::from((3, 1)),
             src: dummy_src(),
         };
         let e2 = ShellError::UnclosedQuote {
-            style: QuoteStyle::Double,
+            style: QuoteKind::Double,
             span: SourceSpan::from((3, 1)),
             src: dummy_src(),
         };

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,43 +14,44 @@ use crate::{
     error::{ShellError, ShellResult},
     exit::ExitCode,
     fs,
-    parser::Pipeline,
     redirect::{RedirectMode, StderrRedirection, StdoutRedirection},
-    Command,
+    resolver::ResolvedPipeline,
+    CommandKind,
 };
 
-enum CommandKind {
+/// Result of looking up a command name for the `type` builtin.
+enum CmdLookup {
     Builtin(BuiltInName),
     Executable(PathBuf),
     NotFound,
 }
 
-fn resolve_command_type(name: &[u8]) -> CommandKind {
+fn resolve_command_type(name: &[u8]) -> CmdLookup {
     if !name.is_ascii() {
-        return CommandKind::NotFound;
+        return CmdLookup::NotFound;
     }
 
     let name_str = std::str::from_utf8(name).expect("checked ASCII above");
 
     if let Ok(builtin_name) = BuiltInName::from_str(name_str) {
-        return CommandKind::Builtin(builtin_name);
+        return CmdLookup::Builtin(builtin_name);
     }
 
     for dir in get_path_dirs() {
         let candidate = dir.join(name_str);
         if candidate.is_executable() {
-            return CommandKind::Executable(candidate);
+            return CmdLookup::Executable(candidate);
         }
         #[cfg(windows)]
         {
             let candidate_exe = dir.join(format!("{name_str}.exe"));
             if candidate_exe.is_executable() {
-                return CommandKind::Executable(candidate_exe);
+                return CmdLookup::Executable(candidate_exe);
             }
         }
     }
 
-    CommandKind::NotFound
+    CmdLookup::NotFound
 }
 
 /// Open a redirect target file according to its [`RedirectMode`].
@@ -95,9 +96,9 @@ enum StageError {
 /// Handle returned after launching one pipeline stage.
 enum StageHandle {
     /// A builtin running in a background thread.
-    Thread(JoinHandle<ShellResult<Option<ExitCode>>>, Command),
+    Thread(JoinHandle<ShellResult<Option<ExitCode>>>, CommandKind),
     /// A spawned OS process.
-    Process(Child, Command),
+    Process(Child, CommandKind),
 }
 
 /// Single dispatch for launching any pipeline stage — builtin or executable.
@@ -109,7 +110,7 @@ enum StageHandle {
 /// [`StageHandle`]; output flows directly through inherited fds or pipe ends
 /// with no intermediate buffering.
 fn launch_stage(
-    command: Command,
+    command: CommandKind,
     args: Args,
     stdin: Option<PipeReader>,
     stdout: StageOutput,
@@ -117,8 +118,8 @@ fn launch_stage(
     ctx: &mut ShellCtx,
 ) -> ShellResult<StageHandle> {
     match command {
-        Command::BuiltIn(builtin) => {
-            let cmd_for_handle = Command::BuiltIn(builtin.clone());
+        CommandKind::BuiltIn(builtin) => {
+            let cmd_for_handle = CommandKind::BuiltIn(builtin.clone());
             let mut out_w: Box<dyn Write + Send> = match stdout {
                 StageOutput::Pipe(pw) => Box::new(pw),
                 StageOutput::File(f) => Box::new(f),
@@ -139,14 +140,14 @@ fn launch_stage(
                     &mut ctx_clone,
                 )
                 .map_err(|e| ShellError::InCommand {
-                    command: Command::BuiltIn(builtin),
+                    command: CommandKind::BuiltIn(builtin),
                     source: Box::new(e),
                 })
             });
             Ok(StageHandle::Thread(h, cmd_for_handle))
         }
 
-        Command::Executable(executable) => {
+        CommandKind::Executable(executable) => {
             let stdin_stdio = stdin.map_or(Stdio::inherit(), Stdio::from);
             let stdout_stdio = match stdout {
                 StageOutput::Pipe(pw) => Stdio::from(pw),
@@ -166,29 +167,26 @@ fn launch_stage(
                 .stderr(stderr_stdio)
                 .spawn()
             {
-                Ok(child) => Ok(StageHandle::Process(child, Command::Executable(executable))),
+                Ok(child) => Ok(StageHandle::Process(
+                    child,
+                    CommandKind::Executable(executable),
+                )),
                 Err(e) => Err(ShellError::InCommand {
-                    command: Command::Executable(executable),
+                    command: CommandKind::Executable(executable),
                     source: Box::new(ShellError::ExecutionFailed(e)),
                 }),
             }
         }
-
-        Command::Unrecognized { bytes, span, src } => Err(ShellError::CommandNotFound {
-            name: String::from_utf8_lossy(&bytes).into_owned(),
-            span,
-            src,
-        }),
     }
 }
 
-/// Dispatch and execute a single parsed command with optional redirects.
+/// Dispatch and execute a single resolved command with optional redirects.
 ///
 /// Builtins run synchronously in the caller's `ctx` so state-mutating commands
 /// like `cd` propagate back to the shell — matching POSIX semantics for
 /// commands that are not part of a multi-command pipeline.
 pub fn execute(
-    command: Command,
+    command: CommandKind,
     args: Args,
     ctx: &mut ShellCtx,
     stdout_redirect: Option<StdoutRedirection>,
@@ -202,19 +200,19 @@ pub fn execute(
         .transpose()?;
 
     match command {
-        Command::BuiltIn(builtin) => {
+        CommandKind::BuiltIn(builtin) => {
             let mut stdout_default = std::io::stdout();
             let mut stderr_default = std::io::stderr();
             let out: &mut dyn Write = out_file.as_mut().map_or(&mut stdout_default as _, |f| f);
             let err: &mut dyn Write = err_file.as_mut().map_or(&mut stderr_default as _, |f| f);
             execute_builtin(&builtin, args, None, out, err, ctx).map_err(|e| {
                 ShellError::InCommand {
-                    command: Command::BuiltIn(builtin),
+                    command: CommandKind::BuiltIn(builtin),
                     source: Box::new(e),
                 }
             })
         }
-        Command::Executable(executable) => {
+        CommandKind::Executable(executable) => {
             let stdout_stdio = out_file.map_or(Stdio::inherit(), Stdio::from);
             let stderr_stdio = err_file.map_or(Stdio::inherit(), Stdio::from);
             let args_strs: Vec<String> = args.iter().map(|a| a.to_string()).collect();
@@ -226,31 +224,26 @@ pub fn execute(
                 .stderr(stderr_stdio)
                 .spawn()
                 .map_err(|e| ShellError::InCommand {
-                    command: Command::Executable(executable.clone()),
+                    command: CommandKind::Executable(executable.clone()),
                     source: Box::new(ShellError::ExecutionFailed(e)),
                 })?;
             let status = child.wait().map_err(|e| ShellError::InCommand {
-                command: Command::Executable(executable.clone()),
+                command: CommandKind::Executable(executable.clone()),
                 source: Box::new(ShellError::ExecutionFailed(e)),
             })?;
             if status.success() {
                 Ok(None)
             } else {
                 Err(ShellError::InCommand {
-                    command: Command::Executable(executable),
+                    command: CommandKind::Executable(executable),
                     source: Box::new(ShellError::NonZeroExit(status)),
                 })
             }
         }
-        Command::Unrecognized { bytes, span, src } => Err(ShellError::CommandNotFound {
-            name: String::from_utf8_lossy(&bytes).into_owned(),
-            span,
-            src,
-        }),
     }
 }
 
-/// Execute a [`Pipeline`] (one or more `|`-connected commands).
+/// Execute a [`ResolvedPipeline`] (one or more `|`-connected commands).
 ///
 /// A single-stage pipeline delegates to [`execute`]. A multi-stage pipeline
 /// creates N-1 OS-level inter-stage pipes, launches all N stages concurrently,
@@ -259,13 +252,22 @@ pub fn execute(
 /// stdout and stderr fds.
 ///
 /// Returns `Ok(Some(code))` when the last stage requests shell exit, `Ok(None)` otherwise.
-pub fn execute_pipeline(pipeline: Pipeline, ctx: &mut ShellCtx) -> ShellResult<Option<ExitCode>> {
-    if pipeline.len() == 1 {
-        let (cmd, args, stdout_redir, stderr_redir) = pipeline.into_iter().next().unwrap();
-        return execute(cmd, args, ctx, stdout_redir, stderr_redir);
+pub fn execute_pipeline(
+    pipeline: ResolvedPipeline,
+    ctx: &mut ShellCtx,
+) -> ShellResult<Option<ExitCode>> {
+    if pipeline.stages.len() == 1 {
+        let stage = pipeline.stages.into_iter().next().unwrap();
+        return execute(
+            stage.command.kind,
+            stage.args,
+            ctx,
+            stage.stdout_redirect,
+            stage.stderr_redirect,
+        );
     }
 
-    let stages: Vec<_> = pipeline.into_iter().collect();
+    let stages = pipeline.stages;
     let n = stages.len();
 
     let pipe_pairs: std::io::Result<Vec<_>> = (0..n - 1).map(|_| std::io::pipe()).collect();
@@ -277,7 +279,12 @@ pub fn execute_pipeline(pipeline: Pipeline, ctx: &mut ShellCtx) -> ShellResult<O
 
     let mut handles = Vec::with_capacity(n);
 
-    for (i, (command, args, stdout_redirect, stderr_redirect)) in stages.into_iter().enumerate() {
+    for (i, stage) in stages.into_iter().enumerate() {
+        let command = stage.command.kind;
+        let args = stage.args;
+        let stdout_redirect = stage.stdout_redirect;
+        let stderr_redirect = stage.stderr_redirect;
+
         let stdin: Option<PipeReader> = if i == 0 { None } else { readers[i - 1].take() };
 
         let stdout = if let Some(r) = stdout_redirect {
@@ -477,12 +484,12 @@ fn execute_type(args: Args, out: &mut dyn Write) -> ShellResult<()> {
     let name = arg.as_bytes();
 
     match resolve_command_type(name) {
-        CommandKind::Builtin(builtin_name) => writeln!(out, "{} is a shell builtin", builtin_name)?,
-        CommandKind::Executable(path) => {
+        CmdLookup::Builtin(builtin_name) => writeln!(out, "{} is a shell builtin", builtin_name)?,
+        CmdLookup::Executable(path) => {
             let display_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
             writeln!(out, "{} is {}", display_name, path.display())?
         }
-        CommandKind::NotFound => {
+        CmdLookup::NotFound => {
             return Err(ShellError::CommandNotFound {
                 name: arg.to_string(),
                 span: arg.span(),

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -73,5 +73,4 @@ mod tests {
         assert_eq!(ExitCode(0).to_string(), "0");
         assert_eq!(ExitCode(42).to_string(), "42");
     }
-
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,7 +3,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub(crate) fn resolve_path(path: &PathBuf, home_dir: Option<&Path>, cwd: &Path) -> io::Result<PathBuf> {
+pub(crate) fn resolve_path(
+    path: &PathBuf,
+    home_dir: Option<&Path>,
+    cwd: &Path,
+) -> io::Result<PathBuf> {
     let path = if path.is_absolute() {
         path.clone()
     } else if let Ok(stripped) = path.strip_prefix("~") {
@@ -89,7 +93,10 @@ mod tests {
         let cwd = fake_cwd();
         let path = PathBuf::from("./subdir/nested/file");
         let resolved = resolve_path(&path, None, &cwd).unwrap();
-        assert_eq!(resolved, canonicalize_path(cwd.join("subdir/nested/file")).unwrap());
+        assert_eq!(
+            resolved,
+            canonicalize_path(cwd.join("subdir/nested/file")).unwrap()
+        );
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,338 @@
+use std::fmt;
+
+use bytes::Bytes;
+use miette::SourceSpan;
+
+use crate::error::ShellError;
+use crate::input::{Input, InputSource};
+
+/// The kind of quote that was opened but never closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuoteKind {
+    /// A single-quote (`'`) was opened but never closed.
+    Single,
+    /// A double-quote (`"`) was opened but never closed.
+    Double,
+}
+
+impl fmt::Display for QuoteKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuoteKind::Single => write!(f, "single"),
+            QuoteKind::Double => write!(f, "double"),
+        }
+    }
+}
+
+/// The syntactic kind of a lexed token.
+#[derive(Debug, Clone)]
+pub enum TokenKind {
+    /// An unquoted word segment. May include redirect operator spellings such as
+    /// `>` or `2>>`; the parser classifies those.
+    Word(Bytes),
+    /// Content of a single-quoted string (`'...'`). The span includes both quote
+    /// characters; the content bytes have the quotes stripped.
+    SingleQuoted(Bytes),
+    /// Content of a double-quoted string (`"..."`), with `\\` and `\"` escapes
+    /// resolved. The span includes both quote characters.
+    DoubleQuoted(Bytes),
+    /// An unquoted `|` character — always a pipeline separator.
+    Pipe,
+}
+
+/// A single token produced by the lexer.
+#[derive(Debug, Clone)]
+pub struct Token {
+    /// The syntactic content and kind of this token.
+    pub kind: TokenKind,
+    /// Byte offset and length of this token in the raw input line.
+    pub span: SourceSpan,
+    /// The raw input line this token was lexed from.
+    pub src: InputSource,
+}
+
+/// Lex a raw input line into a flat sequence of tokens.
+///
+/// Recognises single-quoted strings, double-quoted strings (with `\\`/`\"`
+/// escapes), backslash escapes outside quotes, and unquoted `|` as a pipeline
+/// separator. Whitespace delimits tokens but is not itself emitted.
+///
+/// All token spans are absolute byte offsets into the original (un-trimmed)
+/// input, so diagnostics render correctly without any caller-side adjustment.
+///
+/// # Errors
+///
+/// Returns [`ShellError::UnclosedQuote`] if a quote is opened but never closed.
+pub fn lex(input: &Input) -> Result<Vec<Token>, ShellError> {
+    let buffer = input.trimmed_bytes();
+    let abs_start = input.leading_offset();
+    let src = input.as_source();
+
+    let mut tokens: Vec<Token> = Vec::new();
+    // Shared accumulation buffer — flushed on each Word/Quoted token emission.
+    let mut word_buf: Vec<u8> = Vec::new();
+    // Absolute start of the current Word token; None when no Word is in progress.
+    let mut word_start_abs: Option<usize> = None;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    // Buffer index of the opening quote character, for span and error reporting.
+    let mut quote_start_i: usize = 0;
+
+    let mut i = 0;
+    while i < buffer.len() {
+        let byte = buffer[i];
+
+        if in_single_quote {
+            if byte == b'\'' {
+                let span = SourceSpan::from((abs_start + quote_start_i, i - quote_start_i + 1));
+                tokens.push(Token {
+                    kind: TokenKind::SingleQuoted(Bytes::from(std::mem::take(&mut word_buf))),
+                    span,
+                    src: src.clone(),
+                });
+                in_single_quote = false;
+            } else {
+                word_buf.push(byte);
+            }
+        } else if in_double_quote {
+            if byte == b'"' {
+                let span = SourceSpan::from((abs_start + quote_start_i, i - quote_start_i + 1));
+                tokens.push(Token {
+                    kind: TokenKind::DoubleQuoted(Bytes::from(std::mem::take(&mut word_buf))),
+                    span,
+                    src: src.clone(),
+                });
+                in_double_quote = false;
+            } else if byte == b'\\' && i + 1 < buffer.len() {
+                let next = buffer[i + 1];
+                if next == b'"' || next == b'\\' {
+                    i += 1;
+                    word_buf.push(next);
+                } else {
+                    word_buf.push(b'\\');
+                }
+            } else {
+                word_buf.push(byte);
+            }
+        } else if byte == b'\'' {
+            flush_word(
+                &mut word_buf,
+                &mut word_start_abs,
+                abs_start + i,
+                &src,
+                &mut tokens,
+            );
+            quote_start_i = i;
+            in_single_quote = true;
+        } else if byte == b'"' {
+            flush_word(
+                &mut word_buf,
+                &mut word_start_abs,
+                abs_start + i,
+                &src,
+                &mut tokens,
+            );
+            quote_start_i = i;
+            in_double_quote = true;
+        } else if byte == b'\\' {
+            if word_start_abs.is_none() {
+                word_start_abs = Some(abs_start + i);
+            }
+            if i + 1 < buffer.len() {
+                i += 1;
+                word_buf.push(buffer[i]);
+            }
+        } else if byte.is_ascii_whitespace() {
+            flush_word(
+                &mut word_buf,
+                &mut word_start_abs,
+                abs_start + i,
+                &src,
+                &mut tokens,
+            );
+        } else if byte == b'|' {
+            flush_word(
+                &mut word_buf,
+                &mut word_start_abs,
+                abs_start + i,
+                &src,
+                &mut tokens,
+            );
+            tokens.push(Token {
+                kind: TokenKind::Pipe,
+                span: SourceSpan::from((abs_start + i, 1)),
+                src: src.clone(),
+            });
+        } else {
+            if word_start_abs.is_none() {
+                word_start_abs = Some(abs_start + i);
+            }
+            word_buf.push(byte);
+        }
+
+        i += 1;
+    }
+
+    if in_single_quote {
+        return Err(ShellError::UnclosedQuote {
+            style: QuoteKind::Single,
+            span: SourceSpan::from((abs_start + quote_start_i, 1)),
+            src,
+        });
+    }
+    if in_double_quote {
+        return Err(ShellError::UnclosedQuote {
+            style: QuoteKind::Double,
+            span: SourceSpan::from((abs_start + quote_start_i, 1)),
+            src,
+        });
+    }
+
+    flush_word(
+        &mut word_buf,
+        &mut word_start_abs,
+        abs_start + buffer.len(),
+        &src,
+        &mut tokens,
+    );
+
+    Ok(tokens)
+}
+
+fn flush_word(
+    buf: &mut Vec<u8>,
+    start_abs: &mut Option<usize>,
+    end_abs: usize,
+    src: &InputSource,
+    tokens: &mut Vec<Token>,
+) {
+    if let Some(start) = start_abs.take() {
+        let span = SourceSpan::from((start, end_abs - start));
+        tokens.push(Token {
+            kind: TokenKind::Word(Bytes::from(std::mem::take(buf))),
+            span,
+            src: src.clone(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lex_raw(raw: &[u8]) -> Vec<Token> {
+        lex(&Input::new(raw)).unwrap()
+    }
+
+    fn word_bytes(token: &Token) -> &[u8] {
+        match &token.kind {
+            TokenKind::Word(b) | TokenKind::SingleQuoted(b) | TokenKind::DoubleQuoted(b) => b,
+            TokenKind::Pipe => b"|",
+        }
+    }
+
+    #[test]
+    fn simple_words_split_on_whitespace() {
+        let tokens = lex_raw(b"echo hello world");
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(word_bytes(&tokens[0]), b"echo");
+        assert_eq!(word_bytes(&tokens[1]), b"hello");
+        assert_eq!(word_bytes(&tokens[2]), b"world");
+    }
+
+    #[test]
+    fn pipe_emitted_as_pipe_token() {
+        let tokens = lex_raw(b"echo foo | cat");
+        assert_eq!(tokens.len(), 4);
+        assert!(matches!(tokens[2].kind, TokenKind::Pipe));
+    }
+
+    #[test]
+    fn adjacent_quoted_segments_are_separate_tokens() {
+        let tokens = lex_raw(b"pre'mid'post");
+        assert_eq!(tokens.len(), 3);
+        assert!(matches!(&tokens[0].kind, TokenKind::Word(b) if b.as_ref() == b"pre"));
+        assert!(matches!(&tokens[1].kind, TokenKind::SingleQuoted(b) if b.as_ref() == b"mid"));
+        assert!(matches!(&tokens[2].kind, TokenKind::Word(b) if b.as_ref() == b"post"));
+        // Spans are adjacent
+        let t0_end = tokens[0].span.offset() + tokens[0].span.len();
+        assert_eq!(t0_end, tokens[1].span.offset());
+        let t1_end = tokens[1].span.offset() + tokens[1].span.len();
+        assert_eq!(t1_end, tokens[2].span.offset());
+    }
+
+    #[test]
+    fn single_quote_preserves_spaces() {
+        let tokens = lex_raw(b"'hello    world'");
+        assert_eq!(tokens.len(), 1);
+        assert!(
+            matches!(&tokens[0].kind, TokenKind::SingleQuoted(b) if b.as_ref() == b"hello    world")
+        );
+    }
+
+    #[test]
+    fn double_quote_processes_backslash_escapes() {
+        let tokens = lex_raw(b"\"A \\\" inside\"");
+        assert_eq!(tokens.len(), 1);
+        assert!(
+            matches!(&tokens[0].kind, TokenKind::DoubleQuoted(b) if b.as_ref() == b"A \" inside")
+        );
+    }
+
+    #[test]
+    fn backslash_outside_quotes_escapes_next_char() {
+        let tokens = lex_raw(b"three\\ \\ \\ spaces");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(&tokens[0].kind, TokenKind::Word(b) if b.as_ref() == b"three   spaces"));
+    }
+
+    #[test]
+    fn quoted_pipe_not_a_separator() {
+        let tokens = lex_raw(b"'foo | bar'");
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(&tokens[0].kind, TokenKind::SingleQuoted(_)));
+    }
+
+    #[test]
+    fn unclosed_single_quote_returns_error() {
+        let err = lex(&Input::new(b"echo 'hello")).unwrap_err();
+        assert!(matches!(
+            err,
+            ShellError::UnclosedQuote {
+                style: QuoteKind::Single,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unclosed_double_quote_returns_error() {
+        let err = lex(&Input::new(b"echo \"hello")).unwrap_err();
+        assert!(matches!(
+            err,
+            ShellError::UnclosedQuote {
+                style: QuoteKind::Double,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn unclosed_single_quote_span_offset() {
+        let err = lex(&Input::new(b"echo 'hello")).unwrap_err();
+        if let ShellError::UnclosedQuote { span, .. } = err {
+            assert_eq!(span.offset(), 5);
+        } else {
+            panic!("expected UnclosedQuote");
+        }
+    }
+
+    #[test]
+    fn spans_are_absolute_including_leading_whitespace() {
+        // Input with 2 bytes of leading whitespace; leading_offset = 2.
+        // The word "echo" starts at absolute position 2.
+        let tokens = lex_raw(b"  echo");
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].span.offset(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 #![deny(missing_docs)]
 //! ferrish — an early-stage shell implementation in Rust.
 
-/// CLI argument parsing (--help, --version).
-pub mod cli;
 /// Shell command argument types.
 pub mod arg;
-/// Shell command variants (built-in, executable, unrecognized).
+/// CLI argument parsing (--help, --version).
+pub mod cli;
+/// Shell command variants (built-in, executable).
 pub mod command;
 /// Shell context and configuration.
 pub mod ctx;
@@ -21,15 +21,19 @@ pub mod exit;
 pub mod fs;
 /// Raw input line with trimmed view and leading-offset pre-computed.
 pub mod input;
-/// Input parsing: splits raw bytes into a command and its arguments.
+/// Lexer: tokenizes raw input into [`lexer::Token`] values.
+pub mod lexer;
+/// Input parsing: groups tokens into an unresolved pipeline AST.
 pub mod parser;
 /// I/O redirection descriptors produced by the parser.
 pub mod redirect;
+/// Resolver: maps unresolved commands to [`CommandKind`] variants.
+pub mod resolver;
 /// The interactive REPL shell.
 pub mod shell;
 
 pub use arg::Arg;
-pub use command::Command;
+pub use command::CommandKind;
 pub use ctx::ShellConfig;
 pub use shell::Shell;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,578 +1,334 @@
-use std::str::FromStr;
-
-use is_executable::IsExecutable;
+use bytes::Bytes;
 use miette::SourceSpan;
 
-use crate::arg::{Arg, Args, QuoteStyle};
-use crate::command::builtin::BuiltInCommand;
-use crate::command::executable::ExecutableCommand;
-use crate::command::{builtin, Command};
-use crate::env::get_path_files;
+use crate::arg::{Arg, Args};
 use crate::error::ShellError;
 use crate::input::{Input, InputSource};
+use crate::lexer::{lex, Token, TokenKind};
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 
-/// One stage of a pipeline: the command to run, its arguments, and any
-/// per-stage redirections.
-pub type PipelineStage = (
-    Command,
-    Args,
-    Option<StdoutRedirection>,
-    Option<StderrRedirection>,
-);
+/// The command position of a pipeline stage before resolution.
+#[derive(Debug)]
+pub struct UnresolvedCommand {
+    /// The argument representing the command word.
+    pub word: Arg,
+}
 
-/// A parsed pipeline — one [`PipelineStage`] per `|`-separated segment.
+/// One stage of a pipeline before command resolution.
+#[derive(Debug)]
+pub struct UnresolvedStage {
+    /// The command to run.
+    pub command: UnresolvedCommand,
+    /// Arguments to pass to the command.
+    pub args: Args,
+    /// Optional stdout redirection for this stage.
+    pub stdout_redirect: Option<StdoutRedirection>,
+    /// Optional stderr redirection for this stage.
+    pub stderr_redirect: Option<StderrRedirection>,
+}
+
+/// A parsed pipeline before command resolution.
 ///
 /// A single command with no `|` is represented as a `Vec` of length 1.
-pub type Pipeline = Vec<PipelineStage>;
+#[derive(Debug)]
+pub struct UnresolvedPipeline {
+    /// The stages of the pipeline, one per `|`-separated segment.
+    pub stages: Vec<UnresolvedStage>,
+    /// The raw input source this pipeline was parsed from.
+    pub src: InputSource,
+}
 
-/// Parse a raw input line into a [`Pipeline`].
+/// Parse a raw input line into an [`UnresolvedPipeline`].
 ///
-/// The input is first split on unquoted `|` characters into segments; each
-/// segment is then parsed into a [`PipelineStage`] exactly as a standalone
-/// command would be.
+/// Lexes the input, splits on unquoted `|` tokens, validates that no segment
+/// is empty, and groups adjacent tokens into [`Arg`] values within each stage.
+/// Redirect operators are extracted from the argument list.
 ///
-/// Recognised redirect operators and their meanings:
+/// # Errors
 ///
-/// | Operator      | fd     | mode      |
-/// |---------------|--------|-----------|
-/// | `>` / `1>`    | stdout | overwrite |
-/// | `>>` / `1>>`  | stdout | append    |
-/// | `2>`           | stderr | overwrite |
-/// | `2>>`          | stderr | append    |
-///
-/// When the same fd appears more than once, the **last** operator wins.
-/// Only unquoted redirect operators are recognised; an operator character that
-/// appears inside quotes is treated as a literal argument character.
-pub fn parse(input: &Input) -> Result<Pipeline, ShellError> {
-    let buffer = input.trimmed_bytes();
-    let segments = split_pipeline_segments(buffer);
+/// Returns [`ShellError::UnclosedQuote`] if a quote is never closed, or
+/// [`ShellError::EmptyPipelineSegment`] if a `|` produces an empty stage.
+pub fn parse(input: &Input) -> Result<UnresolvedPipeline, ShellError> {
+    let tokens = lex(input)?;
+    let src = input.as_source();
+
+    // Partition the flat token list into segments on Pipe tokens.
+    let mut segments: Vec<Vec<Token>> = Vec::new();
+    let mut pipe_tokens: Vec<Token> = Vec::new();
+    let mut current: Vec<Token> = Vec::new();
+    for token in tokens {
+        if matches!(token.kind, TokenKind::Pipe) {
+            pipe_tokens.push(token);
+            segments.push(std::mem::take(&mut current));
+        } else {
+            current.push(token);
+        }
+    }
+    segments.push(current);
+
+    // Check for empty segments (whitespace-only between pipes produces no tokens).
     for (i, segment) in segments.iter().enumerate() {
-        if segment.trim_ascii().is_empty() {
-            let seg_offset = segment.as_ptr() as usize - buffer.as_ptr() as usize;
-            // The `|` that produced this empty segment is either:
-            // - after the segment for leading/middle empties (segment ends just before the `|`)
-            // - before the segment for trailing empties (the last segment has no following `|`)
-            let pipe_offset = if i + 1 < segments.len() {
-                seg_offset + segment.len()
+        if segment.is_empty() {
+            let pipe_span = if i < pipe_tokens.len() {
+                // leading or middle empty: point at the pipe that follows the empty segment
+                pipe_tokens[i].span
             } else {
-                seg_offset.saturating_sub(1)
+                // trailing empty: point at the pipe that precedes the empty segment
+                pipe_tokens[i - 1].span
             };
             return Err(ShellError::EmptyPipelineSegment {
-                span: SourceSpan::from((input.leading_offset() + pipe_offset, 1)),
-                src: input.as_source(),
+                span: pipe_span,
+                src: src.clone(),
             });
         }
     }
-    let mut pipeline = Vec::with_capacity(segments.len());
-    for segment in segments {
-        // Absolute byte offset of this segment's first byte within the raw input.
-        let abs_start =
-            input.leading_offset() + (segment.as_ptr() as usize - buffer.as_ptr() as usize);
-        pipeline.push(parse_segment(segment, abs_start, input)?);
-    }
-    Ok(pipeline)
-}
 
-/// Parse a single pipeline segment (bytes between `|` operators) into a
-/// [`PipelineStage`].
-///
-/// `abs_start` is the byte offset of `buffer[0]` within the raw input line,
-/// used to anchor all diagnostic spans to the original string.
-fn parse_segment(
-    buffer: &[u8],
-    abs_start: usize,
-    input: &Input,
-) -> Result<PipelineStage, ShellError> {
-    let (command_bytes, command_span, raw_args) = split_command_and_args(buffer, abs_start, input)?;
-    let src = input.as_source();
-    let command = parse_command(&command_bytes, command_span, src.clone());
-
-    let (args, stdout_redirect, stderr_redirect) = extract_redirects(raw_args);
-
-    let args = args
+    let stages = segments
         .into_iter()
-        .map(|(bytes, style, span)| match style {
-            QuoteStyle::None => Arg::Literal {
-                bytes,
-                span,
-                src: src.clone(),
-            },
-            style => Arg::Quoted {
-                bytes,
-                style,
-                span,
-                src: src.clone(),
-            },
-        })
-        .collect();
-    Ok((command, args, stdout_redirect, stderr_redirect))
+        .map(|seg| build_stage(seg, &src))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(UnresolvedPipeline { stages, src })
 }
 
-/// Split `buffer` on unquoted `|` characters, returning slices into the
-/// original buffer — one per pipeline segment.  Quoted `|` characters are
-/// never treated as separators.  No copying is performed; the returned slices
-/// borrow directly from `buffer`.
-fn split_pipeline_segments(buffer: &[u8]) -> Vec<&[u8]> {
-    let mut segments: Vec<&[u8]> = Vec::new();
-    let mut seg_start = 0;
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut i = 0;
+/// Group a segment's tokens into `Arg` values and extract redirect operators.
+fn build_stage(tokens: Vec<Token>, _src: &InputSource) -> Result<UnresolvedStage, ShellError> {
+    let grouped = group_into_args(tokens);
 
-    while i < buffer.len() {
-        let byte = buffer[i];
-        if in_single_quote {
-            if byte == b'\'' {
-                in_single_quote = false;
+    let mut iter = grouped.into_iter();
+    let command_word = iter.next().expect("empty segment checked above");
+    let rest: Vec<Arg> = iter.collect();
+    let (args, stdout_redirect, stderr_redirect) = extract_redirects(rest);
+
+    Ok(UnresolvedStage {
+        command: UnresolvedCommand { word: command_word },
+        args,
+        stdout_redirect,
+        stderr_redirect,
+    })
+}
+
+/// Group a sequence of non-Pipe tokens into `Arg` values by span adjacency.
+///
+/// Tokens are adjacent when the next token starts exactly where the previous
+/// one ends (no whitespace gap). Adjacent tokens are concatenated into a single
+/// `Arg`; non-adjacent tokens start a new `Arg`.
+fn group_into_args(tokens: Vec<Token>) -> Vec<Arg> {
+    let mut groups: Vec<Vec<Token>> = Vec::new();
+    let mut current: Vec<Token> = Vec::new();
+
+    for token in tokens {
+        let adjacent = current
+            .last()
+            .is_some_and(|last| token.span.offset() == last.span.offset() + last.span.len());
+        if adjacent {
+            current.push(token);
+        } else {
+            if !current.is_empty() {
+                groups.push(std::mem::take(&mut current));
             }
-        } else if in_double_quote {
-            if byte == b'"' {
-                in_double_quote = false;
-            } else if byte == b'\\' && i + 1 < buffer.len() {
-                i += 1; // skip the escaped char; both bytes remain in the slice
-            }
-        } else if byte == b'\'' {
-            in_single_quote = true;
-        } else if byte == b'"' {
-            in_double_quote = true;
-        } else if byte == b'\\' && i + 1 < buffer.len() {
-            // Outside quotes: skip `\X` as a pair so a `|` after `\` is not
-            // treated as a separator (e.g. `echo \| foo` must not split).
-            i += 1;
-        } else if byte == b'|' {
-            segments.push(&buffer[seg_start..i]);
-            seg_start = i + 1;
+            current.push(token);
         }
-        i += 1;
     }
-    segments.push(&buffer[seg_start..]);
-    segments
+    if !current.is_empty() {
+        groups.push(current);
+    }
+
+    groups.into_iter().map(tokens_to_arg).collect()
 }
 
-/// Raw argument token: byte content, quoting style, and absolute source span.
-type RawArg = (Vec<u8>, QuoteStyle, SourceSpan);
+/// Combine a non-empty group of adjacent tokens into a single `Arg`.
+fn tokens_to_arg(group: Vec<Token>) -> Arg {
+    debug_assert!(!group.is_empty());
 
-/// Result of redirect extraction: remaining args, optional stdout [`StdoutRedirection`],
-/// and optional stderr [`StderrRedirection`].
-type ExtractResult = (
-    Vec<RawArg>,
+    let mut combined: Vec<u8> = Vec::new();
+    for token in &group {
+        let content = match &token.kind {
+            TokenKind::Word(b) | TokenKind::SingleQuoted(b) | TokenKind::DoubleQuoted(b) => {
+                b.as_ref()
+            }
+            TokenKind::Pipe => unreachable!("pipe tokens are stripped before grouping"),
+        };
+        combined.extend_from_slice(content);
+    }
+
+    let first = &group[0];
+    let last = &group[group.len() - 1];
+    let span = SourceSpan::from((
+        first.span.offset(),
+        last.span.offset() + last.span.len() - first.span.offset(),
+    ));
+
+    Arg {
+        bytes: Bytes::from(combined),
+        span,
+        src: first.src.clone(),
+        tokens: group,
+    }
+}
+
+/// Scan `args` for unquoted redirect operators, returning the remaining args
+/// plus any stdout and stderr redirections.
+///
+/// An arg is a redirect operator only if it consists of exactly one `Word`
+/// token whose bytes match `>`, `1>`, `>>`, `1>>`, `2>`, or `2>>`. Mixed-quoted
+/// args (e.g. `1'>'`) have multiple tokens and are never treated as operators.
+///
+/// "Last redirect wins" semantics per fd. A trailing operator with no following
+/// filename is kept as a literal argument.
+fn extract_redirects(
+    args: Vec<Arg>,
+) -> (
+    Vec<Arg>,
     Option<StdoutRedirection>,
     Option<StderrRedirection>,
-);
-
-/// Scan `raw_args` for unquoted redirect operators
-/// (`>`, `1>`, `>>`, `1>>`, `2>`, `2>>`).
-///
-/// Returns the remaining argument list (operators and their target filenames
-/// are removed), an optional stdout [`StdoutRedirection`], and an optional stderr
-/// [`StderrRedirection`].  Multiple operators targeting the same fd are allowed;
-/// **only the last one is recorded** (earlier ones are stripped silently
-/// without side-effects such as creating or truncating intermediate targets).
-///
-/// When a redirect operator appears without a following filename token (e.g.
-/// a trailing `>>`), the operator is kept as a normal argument rather than
-/// silently dropped.
-///
-/// # Quoting
-/// Only tokens with [`QuoteStyle::None`] are treated as potential operators.
-/// Mixed-quoted tokens (e.g. `1'>'`, which produces bytes `1>`) carry
-/// [`QuoteStyle::Mixed`] and are therefore never mistaken for operators.
-fn extract_redirects(raw_args: Vec<RawArg>) -> ExtractResult {
-    let mut out_args: Vec<RawArg> = Vec::new();
+) {
+    let mut out: Vec<Arg> = Vec::new();
     let mut stdout_redirect: Option<StdoutRedirection> = None;
     let mut stderr_redirect: Option<StderrRedirection> = None;
 
-    let mut iter = raw_args.into_iter().peekable();
-    while let Some((bytes, style, span)) = iter.next() {
-        // Only treat unquoted tokens as potential redirect operators.
-        if style == QuoteStyle::None {
-            let token = &bytes[..];
-
-            // Classify the token as (is_stdout, mode). Check longer tokens
-            // first so `1>>` / `2>>` are not mistaken for `1>` / `2>`.
-            let op: Option<(bool, RedirectMode)> = if token == b">>" || token == b"1>>" {
-                Some((true, RedirectMode::Append))
-            } else if token == b">" || token == b"1>" {
-                Some((true, RedirectMode::Overwrite))
-            } else if token == b"2>>" {
-                Some((false, RedirectMode::Append))
-            } else if token == b"2>" {
-                Some((false, RedirectMode::Overwrite))
-            } else {
-                None
-            };
-
-            if let Some((is_stdout, mode)) = op {
-                if let Some((target_bytes, _, _)) = iter.next() {
-                    let target =
-                        std::path::PathBuf::from(String::from_utf8_lossy(&target_bytes).as_ref());
-                    if is_stdout {
-                        stdout_redirect = Some(StdoutRedirection::new(mode, target));
-                    } else {
-                        stderr_redirect = Some(StderrRedirection::new(mode, target));
-                    }
+    let mut iter = args.into_iter().peekable();
+    while let Some(arg) = iter.next() {
+        if let Some((is_stdout, mode)) = classify_redirect(&arg) {
+            if let Some(target) = iter.next() {
+                let path = std::path::PathBuf::from(target.to_string());
+                if is_stdout {
+                    stdout_redirect = Some(StdoutRedirection::new(mode, path));
                 } else {
-                    // No filename follows the operator — keep it as a literal
-                    // argument rather than silently dropping it.
-                    out_args.push((bytes, style, span));
-                }
-                continue;
-            }
-        }
-        out_args.push((bytes, style, span));
-    }
-
-    (out_args, stdout_redirect, stderr_redirect)
-}
-
-/// Split a pipeline segment into a command token and zero or more argument tokens.
-///
-/// Handles single-quoted strings: characters inside `'...'` are treated literally —
-/// whitespace is preserved (not used as a delimiter) and backslashes have no special
-/// meaning.
-///
-/// Handles double-quoted strings: characters inside `"..."` are treated mostly literally —
-/// whitespace is preserved (not used as a delimiter). Inside double quotes, `\\` → `\`
-/// and `\"` → `"`; all other `\X` sequences preserve the backslash literally.
-///
-/// Outside quotes, a `\` before any character emits that character literally and
-/// consumes the backslash (e.g. `\ ` → space, `\\` → `\`).
-///
-/// Adjacent quoted and unquoted segments are concatenated into a single token.
-///
-/// Returns `Err(ShellError::UnclosedQuote)` if a quote is opened but never closed.
-fn split_command_and_args(
-    buffer: &[u8],
-    abs_start: usize,
-    input: &Input,
-) -> Result<(Vec<u8>, SourceSpan, Vec<RawArg>), ShellError> {
-    let mut parts: Vec<(Vec<u8>, QuoteStyle, SourceSpan)> = Vec::new();
-
-    let mut current: Vec<u8> = Vec::new();
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut token_started = false;
-    let mut token_style: Option<QuoteStyle> = None;
-    // Absolute byte offset of the first byte of the current token (set when token_started
-    // transitions false → true).
-    let mut token_start_abs: usize = 0;
-    // Absolute byte offset of the opening quote character within the raw input.
-    let mut quote_open_pos: usize = 0;
-
-    let mut i = 0;
-    while i < buffer.len() {
-        let iter_start_i = i;
-        let byte = buffer[i];
-
-        if in_single_quote {
-            if byte == b'\'' {
-                in_single_quote = false;
-            } else {
-                current.push(byte);
-            }
-        } else if in_double_quote {
-            if byte == b'"' {
-                in_double_quote = false;
-            } else if byte == b'\\' && i + 1 < buffer.len() {
-                // Inside double quotes, backslash only escapes `"` and `\`.
-                // For all other characters, the backslash is preserved literally.
-                let next = buffer[i + 1];
-                if next == b'"' || next == b'\\' {
-                    i += 1;
-                    current.push(next);
-                } else {
-                    current.push(b'\\');
+                    stderr_redirect = Some(StderrRedirection::new(mode, path));
                 }
             } else {
-                current.push(byte);
-            }
-        } else if byte == b'\\' {
-            // Outside any quotes: consume the backslash and emit the next byte literally.
-            // If there is no next byte (trailing backslash), consume the backslash silently.
-            if i + 1 < buffer.len() {
-                i += 1;
-                current.push(buffer[i]);
-            }
-            if !token_started {
-                token_start_abs = abs_start + iter_start_i;
-            }
-            token_started = true;
-            token_style = match token_style {
-                None | Some(QuoteStyle::None) => Some(QuoteStyle::None),
-                _ => Some(QuoteStyle::Mixed),
-            };
-        } else if byte == b'\'' {
-            in_single_quote = true;
-            quote_open_pos = abs_start + i;
-            if !token_started {
-                token_start_abs = abs_start + iter_start_i;
-            }
-            token_started = true;
-            if token_style.is_none() {
-                token_style = Some(QuoteStyle::Single);
-            } else if !matches!(token_style, Some(QuoteStyle::Single)) {
-                token_style = Some(QuoteStyle::Mixed);
-            }
-        } else if byte == b'"' {
-            in_double_quote = true;
-            quote_open_pos = abs_start + i;
-            if !token_started {
-                token_start_abs = abs_start + iter_start_i;
-            }
-            token_started = true;
-            if token_style.is_none() {
-                token_style = Some(QuoteStyle::Double);
-            } else if !matches!(token_style, Some(QuoteStyle::Double)) {
-                token_style = Some(QuoteStyle::Mixed);
-            }
-        } else if byte.is_ascii_whitespace() {
-            if token_started || !current.is_empty() {
-                let style = token_style.take().unwrap_or(QuoteStyle::None);
-                let span =
-                    SourceSpan::from((token_start_abs, abs_start + iter_start_i - token_start_abs));
-                parts.push((std::mem::take(&mut current), style, span));
-                token_started = false;
+                // No filename follows — keep the operator as a literal argument.
+                out.push(arg);
             }
         } else {
-            if !token_started {
-                token_start_abs = abs_start + iter_start_i;
-            }
-            current.push(byte);
-            token_started = true;
-            token_style = match token_style {
-                None | Some(QuoteStyle::None) => Some(QuoteStyle::None),
-                _ => Some(QuoteStyle::Mixed),
-            };
+            out.push(arg);
         }
-
-        i += 1;
     }
 
-    if in_single_quote {
-        return Err(ShellError::UnclosedQuote {
-            style: QuoteStyle::Single,
-            span: SourceSpan::from((quote_open_pos, 1)),
-            src: input.as_source(),
-        });
-    }
-    if in_double_quote {
-        return Err(ShellError::UnclosedQuote {
-            style: QuoteStyle::Double,
-            span: SourceSpan::from((quote_open_pos, 1)),
-            src: input.as_source(),
-        });
-    }
-
-    if token_started || !current.is_empty() {
-        let style = token_style.unwrap_or(QuoteStyle::None);
-        let span = SourceSpan::from((token_start_abs, abs_start + buffer.len() - token_start_abs));
-        parts.push((current, style, span));
-    }
-
-    if parts.is_empty() {
-        return Ok((Vec::new(), SourceSpan::from((abs_start, 0)), Vec::new()));
-    }
-
-    let mut iter = parts.into_iter();
-    let (command, _, cmd_span) = iter.next().unwrap_or((
-        Vec::new(),
-        QuoteStyle::None,
-        SourceSpan::from((abs_start, 0)),
-    ));
-    let args: Vec<RawArg> = iter.collect();
-
-    Ok((command, cmd_span, args))
+    (out, stdout_redirect, stderr_redirect)
 }
 
-/// Resolve a raw command token to a [`Command`] variant.
-pub fn parse_command(bytes: &[u8], span: SourceSpan, src: InputSource) -> Command {
-    if !bytes.is_ascii() {
-        return Command::Unrecognized {
-            bytes: bytes.to_vec(),
-            span,
-            src,
-        };
+/// Return the redirect class for `arg` if it is a redirect operator, else `None`.
+fn classify_redirect(arg: &Arg) -> Option<(bool, RedirectMode)> {
+    if arg.tokens.len() != 1 || !matches!(arg.tokens[0].kind, TokenKind::Word(_)) {
+        return None;
     }
-
-    let command = std::str::from_utf8(bytes).expect("checked ASCII above");
-
-    let name = builtin::BuiltInName::from_str(command);
-    if let Ok(name) = name {
-        Command::BuiltIn(BuiltInCommand::new(name))
-    } else {
-        for file in get_path_files().filter(|p| p.is_executable()) {
-            let executable_command = ExecutableCommand::new(file);
-
-            if executable_command.name() == command {
-                return Command::Executable(executable_command);
-            }
-        }
-
-        Command::Unrecognized {
-            bytes: bytes.to_vec(),
-            span,
-            src,
-        }
+    match arg.bytes.as_ref() {
+        b">>" | b"1>>" => Some((true, RedirectMode::Append)),
+        b">" | b"1>" => Some((true, RedirectMode::Overwrite)),
+        b"2>>" => Some((false, RedirectMode::Append)),
+        b"2>" => Some((false, RedirectMode::Overwrite)),
+        _ => None,
     }
-}
-
-/// Parse a raw byte slice into an [`Arg`].
-pub fn parse_arg(arg: &[u8]) -> Arg {
-    Arg::synthetic(arg)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lexer::QuoteKind;
 
-    fn parse_raw(raw: &[u8]) -> Result<Pipeline, ShellError> {
+    fn parse_raw(raw: &[u8]) -> Result<UnresolvedPipeline, ShellError> {
         parse(&Input::new(raw))
     }
 
-    // Helper: split and return command + arg bytes (quoting metadata stripped).
-    fn split(input: &[u8]) -> (Vec<u8>, Vec<Vec<u8>>) {
-        let src = Input::new(input);
-        let (cmd, _, args) = split_command_and_args(input, 0, &src).unwrap();
-        let arg_bytes = args.into_iter().map(|(b, _, _)| b).collect();
-        (cmd, arg_bytes)
+    fn parse_single(raw: &[u8]) -> UnresolvedStage {
+        let mut pipeline = parse_raw(raw).unwrap();
+        assert_eq!(pipeline.stages.len(), 1, "expected exactly one stage");
+        pipeline.stages.remove(0)
     }
 
-    // Helper: split and return command + (bytes, style) pairs.
-    fn split_styled(input: &[u8]) -> (Vec<u8>, Vec<(Vec<u8>, QuoteStyle)>) {
-        let src = Input::new(input);
-        let (cmd, _, args) = split_command_and_args(input, 0, &src).unwrap();
-        let styled = args.into_iter().map(|(b, s, _)| (b, s)).collect();
-        (cmd, styled)
+    fn stage_bytes(stage: &UnresolvedStage) -> (Vec<u8>, Vec<Vec<u8>>) {
+        let cmd = stage.command.word.as_bytes().to_vec();
+        let args = stage.args.iter().map(|a| a.as_bytes().to_vec()).collect();
+        (cmd, args)
     }
+
+    // --- Basic splitting ---
 
     #[test]
     fn test_split_command_and_args() {
-        let (command, args) = split(b"  ls   -la  /home/user  ");
-        assert_eq!(command, b"ls");
+        let stage = parse_single(b"ls -la /home/user");
+        let (cmd, args) = stage_bytes(&stage);
+        assert_eq!(cmd, b"ls");
         assert_eq!(args, vec![b"-la".to_vec(), b"/home/user".to_vec()]);
     }
 
     #[test]
-    fn test_parse_command_empty() {
-        let command = parse_command(b"", SourceSpan::from((0, 0)), InputSource::synthetic());
-        match command {
-            Command::Unrecognized { bytes, .. } => assert_eq!(bytes.len(), 0),
-            _ => panic!("Empty command unexpectedly found as: {}", command),
-        }
-    }
-
-    #[test]
-    fn test_parse_command_unrecognized() {
-        let command = parse_command(
-            b"some_non_existent_command",
-            SourceSpan::from((0, 0)),
-            InputSource::synthetic(),
-        );
-        match command {
-            Command::Unrecognized { bytes, .. } => {
-                assert_eq!(bytes, b"some_non_existent_command");
-            }
-            _ => panic!("Unrecognized command was recognized: {}", command),
-        }
-    }
-
-    #[test]
-    fn test_parse_arg() {
-        let arg = "/home/user".as_bytes();
-        let parsed_arg = parse_arg(arg);
-        assert_eq!(parsed_arg.as_bytes(), arg);
-        assert!(matches!(parsed_arg, Arg::Literal { .. }));
-    }
-
-    #[test]
-    fn test_split_command_and_args_no_args() {
-        let (command, args) = split(b"ls");
-        assert_eq!(command, b"ls");
+    fn test_split_command_no_args() {
+        let stage = parse_single(b"ls");
+        let (cmd, args) = stage_bytes(&stage);
+        assert_eq!(cmd, b"ls");
         assert!(args.is_empty());
     }
 
     #[test]
-    fn test_split_command_and_args_single_arg() {
-        let (command, args) = split(b"ls -la");
-        assert_eq!(command, b"ls");
+    fn test_split_command_single_arg() {
+        let stage = parse_single(b"ls -la");
+        let (cmd, args) = stage_bytes(&stage);
+        assert_eq!(cmd, b"ls");
         assert_eq!(args, vec![b"-la".to_vec()]);
     }
 
     #[test]
-    fn test_split_command_and_args_multiple_spaces() {
-        let (command, args) = split(b"    command    arg1    arg2    arg3    ");
-        assert_eq!(command, b"command");
+    fn test_split_command_multiple_spaces() {
+        let stage = parse_single(b"    command    arg1    arg2    arg3    ");
+        let (cmd, args) = stage_bytes(&stage);
+        assert_eq!(cmd, b"command");
         assert_eq!(
             args,
             vec![b"arg1".to_vec(), b"arg2".to_vec(), b"arg3".to_vec()]
         );
     }
 
-    #[test]
-    fn test_parse_arg_empty() {
-        let arg = "".as_bytes();
-        let parsed_arg = parse_arg(arg);
-        assert!(parsed_arg.as_bytes().is_empty());
-        assert!(matches!(parsed_arg, Arg::Literal { .. }));
-    }
-
-    #[test]
-    fn test_parse_arg_special_chars() {
-        let arg = "file-with_special.chars".as_bytes();
-        let parsed_arg = parse_arg(arg);
-        assert_eq!(parsed_arg.as_bytes(), arg);
-        assert!(matches!(parsed_arg, Arg::Literal { .. }));
-    }
-
     // --- Double-quote tests ---
 
     #[test]
     fn test_double_quote_preserves_spaces() {
-        let (command, args) = split(b"echo \"hello    world\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"hello    world\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"hello    world".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_adjacent_concatenation() {
-        let (command, args) = split(b"echo \"hello\"\"world\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"hello\"\"world\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"helloworld".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_mixed_adjacent_concatenation() {
-        let (command, args) = split(b"echo hello\"world\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo hello\"world\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"helloworld".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_empty_quotes() {
-        let (command, args) = split(b"echo \"\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_multiple_args() {
-        let (command, args) = split(b"echo \"foo bar\" \"baz qux\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"foo bar\" \"baz qux\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"foo bar".to_vec(), b"baz qux".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_with_single_quote_inside() {
-        let (command, args) = split(b"echo \"it's\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"it's\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"it's".to_vec()]);
     }
 
     #[test]
     fn test_double_quote_unquoted_mixed() {
-        let (command, args) = split(b"echo pre\"mid\"post");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo pre\"mid\"post");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"premidpost".to_vec()]);
     }
 
@@ -580,22 +336,22 @@ mod tests {
 
     #[test]
     fn test_dquote_backslash_escapes_backslash() {
-        let (command, args) = split(b"echo \"A \\\\ escapes itself\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"A \\\\ escapes itself\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"A \\ escapes itself".to_vec()]);
     }
 
     #[test]
     fn test_dquote_backslash_escapes_dquote() {
-        let (command, args) = split(b"echo \"A \\\" inside double quotes\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"A \\\" inside double quotes\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"A \" inside double quotes".to_vec()]);
     }
 
     #[test]
     fn test_dquote_backslash_non_special_preserved() {
-        let (command, args) = split(b"echo \"\\n\"");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \"\\n\"");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"\\n".to_vec()]);
     }
 
@@ -603,140 +359,131 @@ mod tests {
 
     #[test]
     fn test_single_quote_preserves_spaces() {
-        let (command, args) = split(b"echo 'hello    world'");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo 'hello    world'");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"hello    world".to_vec()]);
     }
 
     #[test]
     fn test_single_quote_adjacent_concatenation() {
-        let (command, args) = split(b"echo 'hello''world'");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo 'hello''world'");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"helloworld".to_vec()]);
     }
 
     #[test]
     fn test_single_quote_mixed_adjacent_concatenation() {
-        let (command, args) = split(b"echo hello''world");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo hello''world");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"helloworld".to_vec()]);
     }
 
     #[test]
     fn test_single_quote_backslash_literal() {
-        let (command, args) = split(b"echo 'back\\slash'");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo 'back\\slash'");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"back\\slash".to_vec()]);
-    }
-
-    #[test]
-    fn test_single_quote_empty_quotes() {
-        let (command, args) = split(b"echo hello''world");
-        assert_eq!(command, b"echo");
-        assert_eq!(args, vec![b"helloworld".to_vec()]);
     }
 
     // --- Backslash-escape tests (outside quotes) ---
 
     #[test]
     fn test_backslash_space_literal() {
-        let (command, args) = split(b"echo three\\ \\ \\ spaces");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo three\\ \\ \\ spaces");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"three   spaces".to_vec()]);
     }
 
     #[test]
     fn test_backslash_backslash() {
-        let (command, args) = split(b"echo hello\\\\world");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo hello\\\\world");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"hello\\world".to_vec()]);
     }
 
     #[test]
     fn test_backslash_letter() {
-        let (command, args) = split(b"echo test\\nexample");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo test\\nexample");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"testnexample".to_vec()]);
     }
 
     #[test]
     fn test_backslash_single_quote() {
-        let (command, args) = split(b"echo \\'hello\\'");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo \\'hello\\'");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"'hello'".to_vec()]);
     }
 
     #[test]
     fn test_backslash_inside_single_quote_is_literal() {
-        let (command, args) = split(b"echo 'back\\slash'");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo 'back\\slash'");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"back\\slash".to_vec()]);
     }
 
     #[test]
     fn test_trailing_backslash_consumed_silently() {
-        let (command, args) = split(b"echo hello\\");
-        assert_eq!(command, b"echo");
+        let stage = parse_single(b"echo hello\\");
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(args, vec![b"hello".to_vec()]);
     }
 
-    // --- QuoteStyle variant tests ---
+    // --- Token-structure tests (replaces QuoteStyle tests) ---
 
     #[test]
-    fn test_style_unquoted_is_literal() {
-        let (_, args) = split_styled(b"echo hello");
-        assert_eq!(args, vec![(b"hello".to_vec(), QuoteStyle::None)]);
+    fn test_unquoted_arg_has_single_word_token() {
+        let stage = parse_single(b"echo hello");
+        let arg = &stage.args[0];
+        assert_eq!(arg.tokens.len(), 1);
+        assert!(matches!(arg.tokens[0].kind, TokenKind::Word(_)));
     }
 
     #[test]
-    fn test_style_single_quoted() {
-        let (_, args) = split_styled(b"echo 'hello world'");
-        assert_eq!(args, vec![(b"hello world".to_vec(), QuoteStyle::Single)]);
+    fn test_single_quoted_arg_has_single_quoted_token() {
+        let stage = parse_single(b"echo 'hello world'");
+        let arg = &stage.args[0];
+        assert_eq!(arg.tokens.len(), 1);
+        assert!(matches!(arg.tokens[0].kind, TokenKind::SingleQuoted(_)));
     }
 
     #[test]
-    fn test_style_double_quoted() {
-        let (_, args) = split_styled(b"echo \"hello world\"");
-        assert_eq!(args, vec![(b"hello world".to_vec(), QuoteStyle::Double)]);
+    fn test_double_quoted_arg_has_double_quoted_token() {
+        let stage = parse_single(b"echo \"hello world\"");
+        let arg = &stage.args[0];
+        assert_eq!(arg.tokens.len(), 1);
+        assert!(matches!(arg.tokens[0].kind, TokenKind::DoubleQuoted(_)));
     }
 
     #[test]
-    fn test_style_adjacent_single_quoted_stays_single() {
-        let (_, args) = split_styled(b"echo 'hello''world'");
-        assert_eq!(args, vec![(b"helloworld".to_vec(), QuoteStyle::Single)]);
+    fn test_mixed_arg_has_multiple_tokens() {
+        let stage = parse_single(b"echo pre\"mid\"post");
+        let arg = &stage.args[0];
+        assert_eq!(arg.tokens.len(), 3);
+        assert!(matches!(arg.tokens[0].kind, TokenKind::Word(_)));
+        assert!(matches!(arg.tokens[1].kind, TokenKind::DoubleQuoted(_)));
+        assert!(matches!(arg.tokens[2].kind, TokenKind::Word(_)));
     }
 
     #[test]
-    fn test_style_mixed_is_mixed() {
-        let (_, args) = split_styled(b"echo pre\"mid\"post");
-        assert_eq!(args, vec![(b"premidpost".to_vec(), QuoteStyle::Mixed)]);
-    }
-
-    #[test]
-    fn test_style_single_then_double_is_mixed() {
-        let (_, args) = split_styled(b"echo 'a'\"b\"");
-        assert_eq!(args, vec![(b"ab".to_vec(), QuoteStyle::Mixed)]);
-    }
-
-    #[test]
-    fn test_style_unquoted_then_single_is_mixed() {
-        let (_, args) = split_styled(b"echo 1'>'");
-        assert_eq!(args, vec![(b"1>".to_vec(), QuoteStyle::Mixed)]);
+    fn test_mixed_quoted_operator_not_a_redirect() {
+        // 1'>' has two tokens (Word + SingleQuoted) so it is never a redirect.
+        let stage = parse_single(b"echo 1'>'");
+        assert!(stage.stdout_redirect.is_none());
+        assert_eq!(stage.args[0].as_bytes(), b"1>");
+        assert_eq!(stage.args[0].tokens.len(), 2);
     }
 
     // --- Unclosed quote error tests ---
 
     #[test]
     fn test_unclosed_double_quote_returns_error() {
-        let buf = b"echo \"hello";
-        let src = Input::new(buf);
-        let result = split_command_and_args(buf, 0, &src);
-        let err = result.unwrap_err();
+        let err = parse_raw(b"echo \"hello").unwrap_err();
         assert!(
             matches!(
                 err,
                 ShellError::UnclosedQuote {
-                    style: QuoteStyle::Double,
+                    style: QuoteKind::Double,
                     ..
                 }
             ),
@@ -746,9 +493,7 @@ mod tests {
 
     #[test]
     fn test_unclosed_double_quote_span_offset() {
-        let buf = b"echo \"hello";
-        let src = Input::new(buf);
-        let err = split_command_and_args(buf, 0, &src).unwrap_err();
+        let err = parse_raw(b"echo \"hello").unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
             assert_eq!(span.offset(), 5, "quote opens at byte 5 in 'echo \"hello'");
         } else {
@@ -758,15 +503,12 @@ mod tests {
 
     #[test]
     fn test_unclosed_single_quote_returns_error() {
-        let buf = b"echo 'hello";
-        let src = Input::new(buf);
-        let result = split_command_and_args(buf, 0, &src);
-        let err = result.unwrap_err();
+        let err = parse_raw(b"echo 'hello").unwrap_err();
         assert!(
             matches!(
                 err,
                 ShellError::UnclosedQuote {
-                    style: QuoteStyle::Single,
+                    style: QuoteKind::Single,
                     ..
                 }
             ),
@@ -776,9 +518,7 @@ mod tests {
 
     #[test]
     fn test_unclosed_single_quote_span_offset() {
-        let buf = b"echo 'hello";
-        let src = Input::new(buf);
-        let err = split_command_and_args(buf, 0, &src).unwrap_err();
+        let err = parse_raw(b"echo 'hello").unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
             assert_eq!(span.offset(), 5, "quote opens at byte 5 in \"echo 'hello\"");
         } else {
@@ -788,20 +528,15 @@ mod tests {
 
     #[test]
     fn test_unclosed_quote_is_non_fatal() {
-        let buf = b"echo \"unterminated";
-        let src = Input::new(buf);
-        let err = split_command_and_args(buf, 0, &src).unwrap_err();
+        let err = parse_raw(b"echo \"unterminated").unwrap_err();
         assert!(!err.is_fatal());
     }
 
     #[test]
     fn test_pipeline_unclosed_quote_span_accounts_for_leading_whitespace() {
-        // The second segment has one leading space after `|`.
-        // The `"` opens at position 6 within ` echo "bar` (the raw segment),
-        // which starts at byte 10 in the full input. abs_start = 10, i = 6 → span = 16.
+        // `"` is at byte 16 in the full input `echo foo | echo "bar`
         let raw = b"echo foo | echo \"bar";
-        let input = Input::new(raw);
-        let err = parse(&input).unwrap_err();
+        let err = parse_raw(raw).unwrap_err();
         if let ShellError::UnclosedQuote { span, .. } = err {
             assert_eq!(
                 span.offset(),
@@ -813,201 +548,149 @@ mod tests {
         }
     }
 
-    // Helper: parse a single-stage command (no `|`) and extract the one stage.
-    fn parse_single(raw: &[u8]) -> PipelineStage {
-        let input = Input::new(raw);
-        let mut pipeline = parse(&input).unwrap();
-        assert_eq!(pipeline.len(), 1, "expected exactly one pipeline stage");
-        pipeline.remove(0)
-    }
-
     // --- Redirect extraction tests ---
 
     #[test]
     fn test_parse_redirect_gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello > out.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello"]
-        );
-        let r = stdout_redirect.expect("stdout redirect should be Some for >");
+        let stage = parse_single(b"echo hello > out.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec()]);
+        let r = stage
+            .stdout_redirect
+            .expect("stdout redirect should be Some for >");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
-        assert!(stderr_redirect.is_none());
+        assert!(stage.stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_1gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 1> out.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello"]
-        );
-        let r = stdout_redirect.expect("stdout redirect should be Some for 1>");
+        let stage = parse_single(b"echo hello 1> out.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec()]);
+        let r = stage
+            .stdout_redirect
+            .expect("stdout redirect should be Some for 1>");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
-        assert!(stderr_redirect.is_none());
+        assert!(stage.stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello >> out.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello"]
-        );
-        let r = stdout_redirect.expect("stdout redirect should be Some for >>");
+        let stage = parse_single(b"echo hello >> out.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec()]);
+        let r = stage
+            .stdout_redirect
+            .expect("stdout redirect should be Some for >>");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
-        assert!(stderr_redirect.is_none());
+        assert!(stage.stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_1gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 1>> out.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello"]
-        );
-        let r = stdout_redirect.expect("stdout redirect should be Some for 1>>");
+        let stage = parse_single(b"echo hello 1>> out.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec()]);
+        let r = stage
+            .stdout_redirect
+            .expect("stdout redirect should be Some for 1>>");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
-        assert!(stderr_redirect.is_none());
+        assert!(stage.stderr_redirect.is_none());
     }
 
     #[test]
     fn test_parse_redirect_2gt() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello 2> err.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello"]
-        );
-        assert!(
-            stdout_redirect.is_none(),
-            "stdout redirect should be None for 2>"
-        );
-        let r = stderr_redirect.expect("stderr redirect should be Some for 2>");
+        let stage = parse_single(b"echo hello 2> err.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec()]);
+        assert!(stage.stdout_redirect.is_none());
+        let r = stage
+            .stderr_redirect
+            .expect("stderr redirect should be Some for 2>");
         assert_eq!(r.mode, RedirectMode::Overwrite);
         assert_eq!(r.target, std::path::PathBuf::from("err.txt"));
     }
 
     #[test]
     fn test_parse_redirect_2gtgt() {
-        let (_, args, stdout_redirect, stderr_redirect) =
-            parse_single(b"exit notanumber 2>> err.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["notanumber"]
-        );
-        assert!(stdout_redirect.is_none());
-        let r = stderr_redirect.expect("stderr redirect should be Some for 2>>");
+        let stage = parse_single(b"exit notanumber 2>> err.txt");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"notanumber".to_vec()]);
+        assert!(stage.stdout_redirect.is_none());
+        let r = stage
+            .stderr_redirect
+            .expect("stderr redirect should be Some for 2>>");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("err.txt"));
     }
 
     #[test]
     fn test_parse_redirect_last_wins_stdout() {
-        let (_, args, stdout_redirect, _) = parse_single(b"echo hi > first.txt >> last.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hi"]
-        );
-        let r = stdout_redirect.expect("stdout redirect should be Some");
+        let stage = parse_single(b"echo hi > first.txt >> last.txt");
+        let r = stage
+            .stdout_redirect
+            .expect("stdout redirect should be Some");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("last.txt"));
     }
 
     #[test]
     fn test_parse_redirect_last_wins_stderr() {
-        let (_, args, _, stderr_redirect) = parse_single(b"echo hi 2> first.txt 2>> last.txt");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hi"]
-        );
-        let r = stderr_redirect.expect("stderr redirect should be Some");
+        let stage = parse_single(b"echo hi 2> first.txt 2>> last.txt");
+        let r = stage
+            .stderr_redirect
+            .expect("stderr redirect should be Some");
         assert_eq!(r.mode, RedirectMode::Append);
         assert_eq!(r.target, std::path::PathBuf::from("last.txt"));
     }
 
     #[test]
     fn test_parse_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, stdout_redirect, _) = parse_single(b"echo >");
-        assert!(
-            stdout_redirect.is_none(),
-            "no redirect target means no Redirection"
-        );
+        let stage = parse_single(b"echo >");
+        assert!(stage.stdout_redirect.is_none());
+        let (_, args) = stage_bytes(&stage);
         assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec![">"],
+            args,
+            vec![b">".to_vec()],
             "trailing `>` should be kept as a literal arg"
         );
     }
 
     #[test]
     fn test_parse_redirect_trailing_gtgt_kept_as_arg() {
-        let (_, args, stdout_redirect, _) = parse_single(b"echo >>");
-        assert!(
-            stdout_redirect.is_none(),
-            "no redirect target means no Redirection"
-        );
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec![">>"],
-            "trailing `>>` should be kept as a literal arg"
-        );
+        let stage = parse_single(b"echo >>");
+        assert!(stage.stdout_redirect.is_none());
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b">>".to_vec()]);
     }
 
     #[test]
     fn test_parse_stderr_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, _, stderr_redirect) = parse_single(b"echo 2>");
-        assert!(
-            stderr_redirect.is_none(),
-            "no redirect target means no Redirection"
-        );
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["2>"],
-            "trailing `2>` should be kept as a literal arg"
-        );
-    }
-
-    #[test]
-    fn test_parse_mixed_quoted_operator_not_a_redirect() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo 1'>'");
-        assert!(
-            stdout_redirect.is_none(),
-            "mixed-quoted 1'>' must not trigger a redirect"
-        );
-        assert!(stderr_redirect.is_none());
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["1>"],
-        );
+        let stage = parse_single(b"echo 2>");
+        assert!(stage.stderr_redirect.is_none());
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"2>".to_vec()]);
     }
 
     #[test]
     fn test_parse_stderr_append_redirect_trailing_operator_kept_as_arg() {
-        let (_, args, _, stderr_redirect) = parse_single(b"echo 2>>");
-        assert!(
-            stderr_redirect.is_none(),
-            "no redirect target means no Redirection"
-        );
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["2>>"],
-            "trailing `2>>` should be kept as a literal arg"
-        );
+        let stage = parse_single(b"echo 2>>");
+        assert!(stage.stderr_redirect.is_none());
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"2>>".to_vec()]);
     }
 
     #[test]
     fn test_parse_no_redirect() {
-        let (_, args, stdout_redirect, stderr_redirect) = parse_single(b"echo hello world");
-        assert_eq!(
-            args.iter().map(|a: &Arg| a.to_string()).collect::<Vec<_>>(),
-            vec!["hello", "world"]
-        );
-        assert!(stdout_redirect.is_none());
-        assert!(stderr_redirect.is_none());
+        let stage = parse_single(b"echo hello world");
+        let (_, args) = stage_bytes(&stage);
+        assert_eq!(args, vec![b"hello".to_vec(), b"world".to_vec()]);
+        assert!(stage.stdout_redirect.is_none());
+        assert!(stage.stderr_redirect.is_none());
     }
 
     // --- Pipeline splitting tests ---
@@ -1015,52 +698,43 @@ mod tests {
     #[test]
     fn test_pipeline_single_command_gives_one_stage() {
         let p = parse_raw(b"echo hello").unwrap();
-        assert_eq!(p.len(), 1);
+        assert_eq!(p.stages.len(), 1);
     }
 
     #[test]
     fn test_pipeline_two_commands_gives_two_stages() {
         let p = parse_raw(b"echo foo | cat").unwrap();
-        assert_eq!(p.len(), 2);
-        let (cmd0, args0, _, _) = &p[0];
-        let (cmd1, args1, _, _) = &p[1];
-        assert_eq!(cmd0.to_string(), "echo");
-        assert_eq!(
-            args0.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
-            vec!["foo"]
-        );
-        assert_eq!(cmd1.to_string(), "cat");
-        assert!(args1.is_empty());
+        assert_eq!(p.stages.len(), 2);
+        assert_eq!(p.stages[0].command.word.as_bytes(), b"echo");
+        assert_eq!(p.stages[0].args[0].as_bytes(), b"foo");
+        assert_eq!(p.stages[1].command.word.as_bytes(), b"cat");
+        assert!(p.stages[1].args.is_empty());
     }
 
     #[test]
     fn test_pipeline_quoted_pipe_is_not_separator() {
         let p = parse_raw(b"echo 'foo | bar'").unwrap();
-        assert_eq!(p.len(), 1, "quoted | must not split the pipeline");
-        let (_, args, _, _) = &p[0];
-        assert_eq!(
-            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
-            vec!["foo | bar"]
-        );
+        assert_eq!(p.stages.len(), 1, "quoted | must not split the pipeline");
+        assert_eq!(p.stages[0].args[0].as_bytes(), b"foo | bar");
     }
 
     #[test]
     fn test_pipeline_double_quoted_pipe_is_not_separator() {
         let p = parse_raw(b"echo \"foo | bar\"").unwrap();
-        assert_eq!(p.len(), 1, "double-quoted | must not split the pipeline");
-        let (_, args, _, _) = &p[0];
         assert_eq!(
-            args.iter().map(|a| a.to_string()).collect::<Vec<_>>(),
-            vec!["foo | bar"]
+            p.stages.len(),
+            1,
+            "double-quoted | must not split the pipeline"
         );
+        assert_eq!(p.stages[0].args[0].as_bytes(), b"foo | bar");
     }
 
     #[test]
     fn test_pipeline_last_stage_redirect() {
         let p = parse_raw(b"echo foo | cat > out.txt").unwrap();
-        assert_eq!(p.len(), 2);
-        let (_, _, stdout_redir, _) = &p[1];
-        let r = stdout_redir
+        assert_eq!(p.stages.len(), 2);
+        let r = p.stages[1]
+            .stdout_redirect
             .as_ref()
             .expect("last stage should have redirect");
         assert_eq!(r.target, std::path::PathBuf::from("out.txt"));
@@ -1079,7 +753,6 @@ mod tests {
 
     #[test]
     fn test_trailing_pipe_span_points_at_pipe() {
-        // "echo hello |" — `|` is at byte 11
         let err = parse_raw(b"echo hello |").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 11, "`|` is at byte 11 in 'echo hello |'");
@@ -1100,7 +773,6 @@ mod tests {
 
     #[test]
     fn test_leading_pipe_span_points_at_pipe() {
-        // "| cat" — `|` is at byte 0
         let err = parse_raw(b"| cat").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(span.offset(), 0, "`|` is at byte 0 in '| cat'");
@@ -1121,7 +793,6 @@ mod tests {
 
     #[test]
     fn test_empty_middle_segment_span_points_at_second_pipe() {
-        // "echo a | | cat" — second `|` is at byte 9
         let err = parse_raw(b"echo a | | cat").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(
@@ -1146,7 +817,6 @@ mod tests {
 
     #[test]
     fn test_whitespace_only_segment_span_points_at_second_pipe() {
-        // "echo a |   | cat" — second `|` is at byte 11
         let err = parse_raw(b"echo a |   | cat").unwrap_err();
         if let ShellError::EmptyPipelineSegment { span, .. } = err {
             assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,9 +72,12 @@ pub fn parse(input: &Input) -> Result<UnresolvedPipeline, ShellError> {
             let pipe_span = if i < pipe_tokens.len() {
                 // leading or middle empty: point at the pipe that follows the empty segment
                 pipe_tokens[i].span
-            } else {
+            } else if i > 0 {
                 // trailing empty: point at the pipe that precedes the empty segment
                 pipe_tokens[i - 1].span
+            } else {
+                // no pipes at all — input was empty/whitespace; use a zero-length span
+                SourceSpan::from((0_usize, 0_usize))
             };
             return Err(ShellError::EmptyPipelineSegment {
                 span: pipe_span,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,14 +88,14 @@ pub fn parse(input: &Input) -> Result<UnresolvedPipeline, ShellError> {
 
     let stages = segments
         .into_iter()
-        .map(|seg| build_stage(seg, &src))
+        .map(build_stage)
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(UnresolvedPipeline { stages, src })
 }
 
 /// Group a segment's tokens into `Arg` values and extract redirect operators.
-fn build_stage(tokens: Vec<Token>, _src: &InputSource) -> Result<UnresolvedStage, ShellError> {
+fn build_stage(tokens: Vec<Token>) -> Result<UnresolvedStage, ShellError> {
     let grouped = group_into_args(tokens);
 
     let mut iter = grouped.into_iter();

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,172 @@
+use std::str::FromStr;
+
+use is_executable::IsExecutable;
+
+use crate::arg::{Arg, Args};
+use crate::command::builtin::{BuiltInCommand, BuiltInName};
+use crate::command::executable::ExecutableCommand;
+use crate::command::CommandKind;
+use crate::env::get_path_dirs;
+use crate::error::{ShellError, ShellResult};
+use crate::input::InputSource;
+use crate::parser::{UnresolvedPipeline, UnresolvedStage};
+use crate::redirect::{StderrRedirection, StdoutRedirection};
+
+/// A resolved command: its kind (built-in or executable) plus the original word arg.
+#[derive(Debug)]
+pub struct ResolvedCommand {
+    /// The resolved command kind.
+    pub kind: CommandKind,
+    /// The original command word as it appeared in the input.
+    pub word: Arg,
+}
+
+/// One stage of a pipeline after command resolution.
+#[derive(Debug)]
+pub struct ResolvedStage {
+    /// The resolved command.
+    pub command: ResolvedCommand,
+    /// Arguments to pass to the command.
+    pub args: Args,
+    /// Optional stdout redirection for this stage.
+    pub stdout_redirect: Option<StdoutRedirection>,
+    /// Optional stderr redirection for this stage.
+    pub stderr_redirect: Option<StderrRedirection>,
+}
+
+/// A pipeline with all commands resolved to built-ins or executables.
+#[derive(Debug)]
+pub struct ResolvedPipeline {
+    /// The stages of the pipeline, one per `|`-separated segment.
+    pub stages: Vec<ResolvedStage>,
+    /// The raw input source this pipeline was parsed from.
+    pub src: InputSource,
+}
+
+/// Resolve all commands in `pipeline` to [`CommandKind::BuiltIn`] or [`CommandKind::Executable`].
+///
+/// Fails fast on the first unrecognised command with [`ShellError::CommandNotFound`].
+pub fn resolve(pipeline: UnresolvedPipeline) -> ShellResult<ResolvedPipeline> {
+    let stages = pipeline
+        .stages
+        .into_iter()
+        .map(resolve_stage)
+        .collect::<ShellResult<Vec<_>>>()?;
+
+    Ok(ResolvedPipeline {
+        stages,
+        src: pipeline.src,
+    })
+}
+
+fn resolve_stage(stage: UnresolvedStage) -> ShellResult<ResolvedStage> {
+    let word = stage.command.word;
+    let kind = resolve_command(&word)?;
+    Ok(ResolvedStage {
+        command: ResolvedCommand { kind, word },
+        args: stage.args,
+        stdout_redirect: stage.stdout_redirect,
+        stderr_redirect: stage.stderr_redirect,
+    })
+}
+
+fn resolve_command(word: &Arg) -> ShellResult<CommandKind> {
+    let bytes = word.as_bytes();
+
+    if !bytes.is_ascii() {
+        return Err(ShellError::CommandNotFound {
+            name: String::from_utf8_lossy(bytes).into_owned(),
+            span: word.span(),
+            src: word.src(),
+        });
+    }
+
+    let name = std::str::from_utf8(bytes).expect("checked ASCII above");
+
+    if let Ok(builtin_name) = BuiltInName::from_str(name) {
+        return Ok(CommandKind::BuiltIn(BuiltInCommand::new(builtin_name)));
+    }
+
+    for dir in get_path_dirs() {
+        let candidate = dir.join(name);
+        if candidate.is_executable() {
+            return Ok(CommandKind::Executable(ExecutableCommand::new(candidate)));
+        }
+        #[cfg(windows)]
+        {
+            let candidate_exe = dir.join(format!("{name}.exe"));
+            if candidate_exe.is_executable() {
+                return Ok(CommandKind::Executable(ExecutableCommand::new(
+                    candidate_exe,
+                )));
+            }
+        }
+    }
+
+    Err(ShellError::CommandNotFound {
+        name: name.to_string(),
+        span: word.span(),
+        src: word.src(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::Input;
+    use crate::parser;
+
+    fn resolve_raw(raw: &[u8]) -> ShellResult<ResolvedPipeline> {
+        let input = Input::new(raw);
+        let pipeline = parser::parse(&input)?;
+        resolve(pipeline)
+    }
+
+    fn resolve_single(raw: &[u8]) -> ResolvedStage {
+        resolve_raw(raw).unwrap().stages.remove(0)
+    }
+
+    #[test]
+    fn unknown_command_returns_not_found() {
+        let err = resolve_raw(b"some_non_existent_command_xyz").unwrap_err();
+        assert!(
+            matches!(err, ShellError::CommandNotFound { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn non_ascii_command_returns_not_found() {
+        let err = resolve_raw(b"\xff").unwrap_err();
+        assert!(matches!(err, ShellError::CommandNotFound { .. }));
+    }
+
+    #[test]
+    fn builtin_echo_resolves() {
+        let stage = resolve_single(b"echo hello");
+        assert!(matches!(stage.command.kind, CommandKind::BuiltIn(_)));
+    }
+
+    #[test]
+    fn command_not_found_name_and_span() {
+        let err = resolve_raw(b"nonexistent_cmd_xyz").unwrap_err();
+        if let ShellError::CommandNotFound { name, span, .. } = err {
+            assert_eq!(name, "nonexistent_cmd_xyz");
+            assert_eq!(span.offset(), 0);
+            assert_eq!(span.len(), 19);
+        } else {
+            panic!("expected CommandNotFound");
+        }
+    }
+
+    #[test]
+    fn fails_fast_on_first_unknown_in_pipeline() {
+        // Second stage is unknown; error names it, not the first stage.
+        let err = resolve_raw(b"echo foo | unknown_cmd_xyz").unwrap_err();
+        if let ShellError::CommandNotFound { name, .. } = err {
+            assert_eq!(name, "unknown_cmd_xyz");
+        } else {
+            panic!("expected CommandNotFound");
+        }
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -73,6 +73,14 @@ fn resolve_stage(stage: UnresolvedStage) -> ShellResult<ResolvedStage> {
 fn resolve_command(word: &Arg) -> ShellResult<CommandKind> {
     let bytes = word.as_bytes();
 
+    if bytes.is_empty() {
+        return Err(ShellError::CommandNotFound {
+            name: String::new(),
+            span: word.span(),
+            src: word.src(),
+        });
+    }
+
     if !bytes.is_ascii() {
         return Err(ShellError::CommandNotFound {
             name: String::from_utf8_lossy(bytes).into_owned(),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -8,7 +8,7 @@ use crate::{
     executor,
     exit::ExitCode,
     input::Input,
-    parser,
+    parser, resolver,
 };
 
 /// The ferrish shell REPL.
@@ -53,7 +53,14 @@ impl Shell {
                 continue;
             }
 
-            let pipeline = match parser::parse(&input) {
+            let unresolved = match parser::parse(&input) {
+                Ok(r) => r,
+                Err(e) => {
+                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
+                    continue;
+                }
+            };
+            let pipeline = match resolver::resolve(unresolved) {
                 Ok(r) => r,
                 Err(e) => {
                     writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;


### PR DESCRIPTION
Splits the monolithic parser into three clean pipeline stages, closing #116 and #117:

- **Lexer** (`src/lexer.rs`): tokenises raw bytes into `Token { kind, span, src }` with `TokenKind` variants `Word | SingleQuoted | DoubleQuoted | Pipe`.
- **Parser** (`src/parser.rs`): consumes tokens, groups adjacent tokens by span continuity into `Arg` values, and produces an `UnresolvedPipeline`. Redirect operators are only recognised when the arg has exactly one `Word` token (mixed-quoted args like `1'>'` are never treated as operators).
- **Resolver** (`src/resolver.rs`): maps `UnresolvedPipeline → ResolvedPipeline`, failing fast with `CommandNotFound` on the first unknown command.

Supporting changes:
- `Arg` rewritten as a struct (`tokens: Vec<Token>`, `bytes: Bytes`, `span`, `src`); `QuoteStyle` removed — quoting info lives in `TokenKind`.
- `Command` renamed to `CommandKind`; `Command::Unrecognized` removed.
- `executor`: consumes `ResolvedPipeline`; local `CmdLookup` private enum replaces old `Command` shadowing; `get_path_files` removed (dead after resolver owns lookup — see #119).
- `shell`: two-step `parse` + `resolve` with independent error recovery per stage.

Closes #116
Closes #117

Co-Authored-By: Claude <noreply@anthropic.com>