### PR TITLE
feat: multiline input support and input collection redesign

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -7,6 +7,9 @@ use crate::env;
 pub struct ShellConfig {
     /// The prompt string displayed before each input line.
     pub prompt: String,
+    /// The prompt string displayed when more input is needed (line continuation
+    /// or unclosed quote).
+    pub continuation_prompt: String,
     /// Optional path to the shell history file.
     pub history_path: Option<PathBuf>,
     /// Maximum number of history entries to retain.
@@ -17,6 +20,7 @@ impl Default for ShellConfig {
     fn default() -> Self {
         Self {
             prompt: "\u{1F980}> ".to_string(), // 🦀>
+            continuation_prompt: "> ".to_string(),
             history_path: None,
             max_history: 1000,
         }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -85,13 +85,12 @@ impl Shell {
 
 /// Read one logical input line from `reader`, handling line continuations.
 ///
-/// A physical line ending in `\` is joined to the next line (the backslash and
-/// newline are both dropped). A physical line whose accumulated content has an
-/// unclosed quote signals that more input is needed; the newline is kept in the
-/// accumulator so the quoted string receives its literal newline character.
+/// Quote continuation is checked before backslash continuation so that a `\`
+/// inside a quoted string (where it is literal) does not trigger line joining.
+/// Backslash-newline joining is only applied when a real `\n` delimiter was
+/// read; an EOF-terminated chunk ending in `\` is kept as-is.
 ///
-/// In both cases a `cont_prompt` is written to `out` and another physical line
-/// is read. Returns `None` on EOF before any input is accumulated.
+/// Returns `None` on EOF before any input is accumulated.
 fn collect_input(
     reader: &mut dyn BufRead,
     out: &mut dyn Write,
@@ -106,8 +105,22 @@ fn collect_input(
             return Ok(if acc.is_empty() { None } else { Some(acc) });
         }
 
-        let without_newline = line.strip_suffix(b"\n").unwrap_or(&line);
-        if without_newline.ends_with(b"\\") {
+        // Check quote state on acc+line first: a `\` inside a quoted string
+        // is literal and must not be mistaken for a line-continuation marker.
+        let mut candidate = acc.clone();
+        candidate.extend_from_slice(&line);
+        if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&candidate)) {
+            acc = candidate;
+            out.write_all(cont_prompt.as_bytes()).into_diagnostic()?;
+            out.flush().into_diagnostic()?;
+            continue;
+        }
+
+        // Only join lines on `\<newline>` — not on a `\` at EOF with no
+        // following newline (which would silently drop the backslash).
+        if let Some(without_newline) = line.strip_suffix(b"\n")
+            && without_newline.ends_with(b"\\")
+        {
             acc.extend_from_slice(&without_newline[..without_newline.len() - 1]);
             out.write_all(cont_prompt.as_bytes()).into_diagnostic()?;
             out.flush().into_diagnostic()?;
@@ -115,13 +128,6 @@ fn collect_input(
         }
 
         acc.extend_from_slice(&line);
-
-        if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&acc)) {
-            out.write_all(cont_prompt.as_bytes()).into_diagnostic()?;
-            out.flush().into_diagnostic()?;
-            continue;
-        }
-
         return Ok(Some(acc));
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -5,10 +5,11 @@ use miette::IntoDiagnostic as _;
 
 use crate::{
     ctx::{ShellConfig, ShellCtx},
+    error::ShellError,
     executor,
     exit::ExitCode,
     input::Input,
-    parser, resolver,
+    lexer, parser, resolver,
 };
 
 /// The ferrish shell REPL.
@@ -37,16 +38,16 @@ impl Shell {
     pub fn run_repl(&mut self, reader: &mut dyn BufRead) -> miette::Result<ExitCode> {
         let mut out = std::io::stdout();
         let mut err = std::io::stderr();
+        let cont_prompt = self.ctx.config.continuation_prompt.clone();
         loop {
             out.write_all(self.ctx.config.prompt.as_bytes())
                 .into_diagnostic()?;
             out.flush().into_diagnostic()?;
 
-            let mut raw = Vec::<u8>::new();
-            let bytes = reader.read_until(b'\n', &mut raw).into_diagnostic()?;
-            if bytes == 0 {
-                return Ok(ExitCode::SUCCESS);
-            }
+            let raw = match collect_input(reader, &mut out, &cont_prompt)? {
+                None => return Ok(ExitCode::SUCCESS),
+                Some(raw) => raw,
+            };
 
             let input = Input::from_vec(raw);
             if input.is_effectively_empty() {
@@ -79,6 +80,49 @@ impl Shell {
                 }
             }
         }
+    }
+}
+
+/// Read one logical input line from `reader`, handling line continuations.
+///
+/// A physical line ending in `\` is joined to the next line (the backslash and
+/// newline are both dropped). A physical line whose accumulated content has an
+/// unclosed quote signals that more input is needed; the newline is kept in the
+/// accumulator so the quoted string receives its literal newline character.
+///
+/// In both cases a `cont_prompt` is written to `out` and another physical line
+/// is read. Returns `None` on EOF before any input is accumulated.
+fn collect_input(
+    reader: &mut dyn BufRead,
+    out: &mut dyn Write,
+    cont_prompt: &str,
+) -> miette::Result<Option<Vec<u8>>> {
+    let mut acc: Vec<u8> = Vec::new();
+
+    loop {
+        let mut line = Vec::new();
+        let n = reader.read_until(b'\n', &mut line).into_diagnostic()?;
+        if n == 0 {
+            return Ok(if acc.is_empty() { None } else { Some(acc) });
+        }
+
+        let without_newline = line.strip_suffix(b"\n").unwrap_or(&line);
+        if without_newline.ends_with(b"\\") {
+            acc.extend_from_slice(&without_newline[..without_newline.len() - 1]);
+            out.write_all(cont_prompt.as_bytes()).into_diagnostic()?;
+            out.flush().into_diagnostic()?;
+            continue;
+        }
+
+        acc.extend_from_slice(&line);
+
+        if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&acc)) {
+            out.write_all(cont_prompt.as_bytes()).into_diagnostic()?;
+            out.flush().into_diagnostic()?;
+            continue;
+        }
+
+        return Ok(Some(acc));
     }
 }
 

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -15,7 +15,9 @@ fn repl_shows_prompt_at_startup() {
 
 #[test]
 fn repl_ignores_empty_lines() {
-    ShellHarness::new().run("\n\necho test").assert_stdout_contains("test");
+    ShellHarness::new()
+        .run("\n\necho test")
+        .assert_stdout_contains("test");
 }
 
 #[test]
@@ -32,7 +34,8 @@ fn nonzero_exit_from_external_command_reports_error() {
     let out = ShellHarness::new().run("false");
     assert!(
         out.stderr().contains("exited with status") || out.stderr().contains("exited"),
-        "expected exit status error, got: {:?}", out.stderr()
+        "expected exit status error, got: {:?}",
+        out.stderr()
     );
 }
 
@@ -45,25 +48,71 @@ fn nonfatal_error_does_not_stop_subsequent_commands() {
         .assert_stdout_contains("survived");
 }
 
+// When an unclosed quote reaches EOF without being closed, the accumulated
+// input is reported as an UnclosedQuote error. The text after the newline is
+// absorbed into the open quote rather than running as a separate command.
 #[test]
-fn unclosed_double_quote_reports_error_and_continues() {
-    let out = ShellHarness::new().run("echo \"hello\necho survived");
+fn unclosed_double_quote_at_eof_reports_error() {
+    let out = ShellHarness::new().run("echo \"hello\necho inside_quote");
     let err = out.stderr();
-    assert!(err.contains("unclosed") && err.contains("quote"), "got: {err}");
-    out.assert_stdout_contains("survived");
+    assert!(
+        err.contains("unclosed") && err.contains("quote"),
+        "got: {err}"
+    );
+    out.assert_stdout_not_contains("inside_quote");
 }
 
 #[test]
-fn unclosed_single_quote_reports_error_and_continues() {
-    let out = ShellHarness::new().run("echo 'hello\necho survived");
+fn unclosed_single_quote_at_eof_reports_error() {
+    let out = ShellHarness::new().run("echo 'hello\necho inside_quote");
     let err = out.stderr();
-    assert!(err.contains("unclosed") && err.contains("quote"), "got: {err}");
-    out.assert_stdout_contains("survived");
+    assert!(
+        err.contains("unclosed") && err.contains("quote"),
+        "got: {err}"
+    );
+    out.assert_stdout_not_contains("inside_quote");
+}
+
+// A double-quoted string that spans two physical lines is accepted as a single
+// command once the closing quote arrives.
+#[test]
+fn multiline_double_quoted_string_continues_until_closed() {
+    ShellHarness::new()
+        .run("echo \"line one\nline two\"\necho done")
+        .assert_stderr_empty()
+        .assert_stdout_contains("line one")
+        .assert_stdout_contains("line two")
+        .assert_stdout_contains("done");
+}
+
+#[test]
+fn multiline_single_quoted_string_continues_until_closed() {
+    ShellHarness::new()
+        .run("echo 'line one\nline two'\necho done")
+        .assert_stderr_empty()
+        .assert_stdout_contains("line one")
+        .assert_stdout_contains("line two")
+        .assert_stdout_contains("done");
+}
+
+// A trailing backslash joins the next physical line, removing the backslash
+// and newline from the input.
+#[test]
+fn trailing_backslash_joins_next_line() {
+    ShellHarness::new()
+        .run("echo hello \\\nworld\necho done")
+        .assert_stderr_empty()
+        .assert_stdout_contains("hello")
+        .assert_stdout_contains("world")
+        .assert_stdout_contains("done");
 }
 
 #[test]
 fn unknown_command_error_goes_to_stderr_not_stdout() {
     let out = ShellHarness::new().run("commandthatdoesnotexist_xyz");
-    assert!(!out.stderr().is_empty(), "expected error output on stderr for unknown command");
+    assert!(
+        !out.stderr().is_empty(),
+        "expected error output on stderr for unknown command"
+    );
     out.assert_stdout_not_contains("not found");
 }

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -107,6 +107,18 @@ fn trailing_backslash_joins_next_line() {
         .assert_stdout_contains("done");
 }
 
+// A backslash inside a single-quoted string is literal — it must not trigger
+// line continuation. The quoted string should span both lines intact.
+#[test]
+fn backslash_inside_single_quote_is_not_continuation() {
+    ShellHarness::new()
+        .run("echo 'hello \\\nworld'\necho done")
+        .assert_stderr_empty()
+        .assert_stdout_contains("hello")
+        .assert_stdout_contains("world")
+        .assert_stdout_contains("done");
+}
+
 #[test]
 fn unknown_command_error_goes_to_stderr_not_stdout() {
     let out = ShellHarness::new().run("commandthatdoesnotexist_xyz");


### PR DESCRIPTION
Replaces the single `read_until(b'\n')` call in `run_repl` with a `collect_input` helper that accumulates physical lines into one logical input. Two continuation signals are handled: a trailing `\` (backslash and newline are stripped, lines joined directly) and an `UnclosedQuote` from the lexer (newline is preserved so multi-line quoted strings receive their literal content). Each continuation line is prompted with `ShellConfig::continuation_prompt` (new field, default `"> "`). Two existing tests that assumed unclosed quotes produced immediate errors are updated to reflect the new continuation semantics; three new integration tests cover the multi-line double-quote, single-quote, and trailing-backslash cases.

Closes #120