### PR TITLE
feat: integrate rustyline for interactive line editing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,12 @@ cargo clippy --all-targets --all-features -- -D warnings
 
 Input flows through: **Shell** → **Parser** → **Executor** → **BuiltIn | Executable**
 
-- `src/shell.rs` — REPL loop; reads input, calls parser, calls executor, handles fatal vs. recoverable errors
+- `src/shell.rs` — REPL loop; `Shell::run()` drives the interactive loop via rustyline; `Shell::run_repl()` is the future script-mode entry point (BufRead-based); `step()` is the shared parse-and-execute helper
 - `src/parser.rs` — Splits input into command + args; resolves whether the command is a built-in, a PATH executable, or unrecognized
 - `src/executor.rs` — Dispatches to built-in handlers or spawns external processes
 - `src/command/builtin.rs` — Implementations of `exit`, `cd`, `echo`, `pwd`, `type`
 - `src/command/executable.rs` — Wraps an external binary found on PATH
 - `src/error.rs` — `ShellError` enum; distinguishes fatal errors (process spawn/wait failures) from recoverable ones (command not found, bad path)
-- `src/io.rs` — `ShellIo` trait with `StandardIo` (real I/O) and `MockIo` (testing); this abstraction is what makes unit tests possible without spawning a process
 - `src/ctx.rs` — `ShellCtx` (runtime state: cwd, home dir, config) and `ShellConfig` (prompt, history settings)
 - `src/arg.rs` — `Arg` enum representing a parsed command argument (currently a `Literal` byte-sequence variant)
 - `src/env.rs` — PATH resolution, home directory lookup, and current-directory helpers
@@ -47,10 +46,12 @@ Input flows through: **Shell** → **Parser** → **Executor** → **BuiltIn | E
 
 Two layers:
 
-1. **Unit tests** — embedded in each module via `#[cfg(test)]`, use `MockIo` for I/O
-2. **Integration tests** (`tests/`) — exercise the `ferrish::Shell` library via the `ShellTest` harness in `tests/harness.rs`, using `MockIo` for I/O
+1. **Unit tests** — embedded in each module via `#[cfg(test)]`
+2. **Integration tests** (`tests/`) — spawn the `ferrish` binary as a subprocess via `ShellHarness` in `tests/common/mod.rs`, feed commands via stdin, and capture stdout/stderr/exit code
 
-The `ShellTest` builder in `harness.rs` is the primary integration test interface. It runs the shell in-process, creates an isolated `HOME` via `tempfile`, and captures stdout/stderr. Prefer integration tests for anything user-visible.
+`ShellHarness` is the primary integration test interface. It runs in an isolated `tempfile` directory. Prefer integration tests for anything user-visible.
+
+Note: integration tests pipe stdin to the binary (non-TTY). The interactive rustyline path (`Shell::run`) suppresses the prompt in non-TTY mode, which is correct shell behavior — tests should not assert on prompt output.
 
 ## Key Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +181,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -184,10 +205,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ferrish"
@@ -197,6 +235,7 @@ dependencies = [
  "clap",
  "is_executable",
  "miette",
+ "rustyline",
  "soft-canonicalize",
  "strum",
  "tempfile",
@@ -248,6 +287,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "id-arena"
@@ -364,6 +412,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +503,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +529,28 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -499,6 +600,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soft-canonicalize"
@@ -635,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,11 +831,29 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -736,20 +867,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -759,9 +912,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -771,9 +936,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -783,15 +960,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1"
 clap = { version = "4", features = ["derive"] }
 is_executable = "1.0"
 miette = { version = "7", features = ["fancy"] }
+rustyline = "14"
 soft-canonicalize = { version = "0.5.4", features = ["dunce"] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "1.0"

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,7 +1,9 @@
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 use miette::IntoDiagnostic as _;
+use rustyline::DefaultEditor;
+use rustyline::error::ReadlineError;
 
 use crate::{
     ctx::{ShellConfig, ShellCtx},
@@ -23,67 +25,140 @@ impl Shell {
         ShellBuilder::default()
     }
 
-    /// Run the interactive REPL loop, reading from stdin until `exit` is called
-    /// or stdin is exhausted. Prompts and diagnostics go to the process's real
-    /// stdout/stderr.
+    /// Run the interactive REPL using rustyline for line editing.
+    ///
+    /// Reads from the terminal until `exit` is called or the user signals EOF
+    /// (Ctrl+D). Ctrl+C abandons the current input and returns to the prompt.
+    /// Diagnostics go to the process's real stderr.
     pub fn run(&mut self) -> miette::Result<ExitCode> {
-        let stdin = std::io::stdin();
-        let mut reader = BufReader::new(stdin.lock());
-        self.run_repl(&mut reader)
-    }
-
-    /// Run the REPL loop with injectable stdin — useful for driving the shell
-    /// from a script or test without spawning a subprocess. Prompts and
-    /// diagnostics still go to the process's real stdout/stderr.
-    pub fn run_repl(&mut self, reader: &mut dyn BufRead) -> miette::Result<ExitCode> {
-        let mut out = std::io::stdout();
+        let mut rl = DefaultEditor::new().into_diagnostic()?;
         let mut err = std::io::stderr();
-        let cont_prompt = self.ctx.config.continuation_prompt.clone();
         loop {
-            out.write_all(self.ctx.config.prompt.as_bytes())
-                .into_diagnostic()?;
-            out.flush().into_diagnostic()?;
-
-            let raw = match collect_input(reader, &mut out, &cont_prompt)? {
+            let raw = match self.collect_input(&mut rl)? {
                 None => return Ok(ExitCode::SUCCESS),
                 Some(raw) => raw,
             };
-
-            let input = Input::from_vec(raw);
-            if input.is_effectively_empty() {
-                continue;
-            }
-
-            let unresolved = match parser::parse(&input) {
-                Ok(r) => r,
-                Err(e) => {
-                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
-                    continue;
-                }
-            };
-            let pipeline = match resolver::resolve(unresolved) {
-                Ok(r) => r,
-                Err(e) => {
-                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
-                    continue;
-                }
-            };
-            match executor::execute_pipeline(pipeline, &mut self.ctx) {
-                Ok(Some(exit_code)) => return Ok(exit_code),
-                Ok(None) => {}
-                Err(e) => {
-                    let fatal = e.is_fatal();
-                    writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
-                    if fatal {
-                        return Ok(ExitCode::FAILURE);
-                    }
-                }
+            if let Some(exit_code) = self.step(raw, &mut err)? {
+                return Ok(exit_code);
             }
         }
     }
+
+    /// Run the shell loop from a [`BufRead`] source.
+    ///
+    /// This is the entry point for future script / batch mode; interactive use
+    /// goes through [`Shell::run`]. Prompts and diagnostics go to the process's
+    /// real stdout/stderr.
+    pub fn run_repl(&mut self, reader: &mut dyn BufRead) -> miette::Result<ExitCode> {
+        let mut out = std::io::stdout();
+        let mut err = std::io::stderr();
+        let prompt = self.ctx.config.prompt.clone();
+        let cont_prompt = self.ctx.config.continuation_prompt.clone();
+        loop {
+            out.write_all(prompt.as_bytes()).into_diagnostic()?;
+            out.flush().into_diagnostic()?;
+
+            let raw = match collect_input_from_reader(reader, &mut out, &cont_prompt)? {
+                None => return Ok(ExitCode::SUCCESS),
+                Some(raw) => raw,
+            };
+            if let Some(exit_code) = self.step(raw, &mut err)? {
+                return Ok(exit_code);
+            }
+        }
+    }
+
+    /// Collect one logical input line from rustyline, handling quote and
+    /// backslash-newline continuation.
+    fn collect_input(&self, rl: &mut DefaultEditor) -> miette::Result<Option<Vec<u8>>> {
+        let prompt = &self.ctx.config.prompt;
+        let cont_prompt = &self.ctx.config.continuation_prompt;
+        let mut acc: Vec<u8> = Vec::new();
+
+        loop {
+            let current = if acc.is_empty() {
+                prompt.as_str()
+            } else {
+                cont_prompt.as_str()
+            };
+
+            let line = match rl.readline(current) {
+                Ok(l) => l,
+                Err(ReadlineError::Eof) => {
+                    return Ok(if acc.is_empty() { None } else { Some(acc) });
+                }
+                Err(ReadlineError::Interrupted) => {
+                    // Ctrl+C: abandon current input and restart prompt.
+                    acc.clear();
+                    continue;
+                }
+                Err(e) => return Err(miette::miette!("{e}")),
+            };
+
+            let line_bytes = line.as_bytes();
+            let mut candidate = acc.clone();
+            candidate.extend_from_slice(line_bytes);
+            candidate.push(b'\n');
+
+            // Check quote state before checking backslash continuation — a `\`
+            // inside a quoted string is literal and must not trigger line joining.
+            if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&candidate)) {
+                acc = candidate;
+                continue;
+            }
+
+            // Backslash-newline: join this line to the next, stripping the `\`.
+            if line_bytes.ends_with(b"\\") {
+                acc.extend_from_slice(&line_bytes[..line_bytes.len() - 1]);
+                continue;
+            }
+
+            let _ = rl.add_history_entry(line.as_str());
+            acc.extend_from_slice(line_bytes);
+            acc.push(b'\n');
+            return Ok(Some(acc));
+        }
+    }
+
+    /// Parse and execute one logical input unit. Returns `Some(code)` when the
+    /// shell should exit, `None` to continue the REPL loop.
+    fn step(&mut self, raw: Vec<u8>, err: &mut dyn Write) -> miette::Result<Option<ExitCode>> {
+        let input = Input::from_vec(raw);
+        if input.is_effectively_empty() {
+            return Ok(None);
+        }
+
+        let unresolved = match parser::parse(&input) {
+            Ok(r) => r,
+            Err(e) => {
+                writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
+                return Ok(None);
+            }
+        };
+        let pipeline = match resolver::resolve(unresolved) {
+            Ok(r) => r,
+            Err(e) => {
+                writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
+                return Ok(None);
+            }
+        };
+        match executor::execute_pipeline(pipeline, &mut self.ctx) {
+            Ok(Some(exit_code)) => return Ok(Some(exit_code)),
+            Ok(None) => {}
+            Err(e) => {
+                let fatal = e.is_fatal();
+                writeln!(err, "{:?}", miette::Report::new(e)).into_diagnostic()?;
+                if fatal {
+                    return Ok(Some(ExitCode::FAILURE));
+                }
+            }
+        }
+        Ok(None)
+    }
 }
 
-/// Read one logical input line from `reader`, handling line continuations.
+/// Read one logical input line from `reader`, handling quote and
+/// backslash-newline continuation.
 ///
 /// Quote continuation is checked before backslash continuation so that a `\`
 /// inside a quoted string (where it is literal) does not trigger line joining.
@@ -91,7 +166,7 @@ impl Shell {
 /// read; an EOF-terminated chunk ending in `\` is kept as-is.
 ///
 /// Returns `None` on EOF before any input is accumulated.
-fn collect_input(
+fn collect_input_from_reader(
     reader: &mut dyn BufRead,
     out: &mut dyn Write,
     cont_prompt: &str,
@@ -105,8 +180,6 @@ fn collect_input(
             return Ok(if acc.is_empty() { None } else { Some(acc) });
         }
 
-        // Check quote state on acc+line first: a `\` inside a quoted string
-        // is literal and must not be mistaken for a line-continuation marker.
         let mut candidate = acc.clone();
         candidate.extend_from_slice(&line);
         if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&candidate)) {
@@ -116,8 +189,6 @@ fn collect_input(
             continue;
         }
 
-        // Only join lines on `\<newline>` — not on a `\` at EOF with no
-        // following newline (which would silently drop the backslash).
         if let Some(without_newline) = line.strip_suffix(b"\n")
             && without_newline.ends_with(b"\\")
         {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -92,20 +92,23 @@ impl Shell {
                     acc.clear();
                     continue;
                 }
-                Err(e) => return Err(miette::miette!("{e}")),
+                Err(e) => return Err(e).into_diagnostic(),
             };
 
             let line_bytes = line.as_bytes();
-            let mut candidate = acc.clone();
-            candidate.extend_from_slice(line_bytes);
-            candidate.push(b'\n');
+            // Extend in-place for the quote check — avoids cloning acc each iteration.
+            let acc_len = acc.len();
+            acc.extend_from_slice(line_bytes);
+            acc.push(b'\n');
 
             // Check quote state before checking backslash continuation — a `\`
             // inside a quoted string is literal and must not trigger line joining.
-            if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&candidate)) {
-                acc = candidate;
+            if let Err(ShellError::UnclosedQuote { .. }) = lexer::lex(&Input::new(&acc)) {
                 continue;
             }
+
+            // Roll back the temporary append; backslash and normal paths rebuild correctly.
+            acc.truncate(acc_len);
 
             // Backslash-newline: join this line to the next, stripping the `\`.
             if line_bytes.ends_with(b"\\") {
@@ -113,9 +116,14 @@ impl Shell {
                 continue;
             }
 
-            let _ = rl.add_history_entry(line.as_str());
             acc.extend_from_slice(line_bytes);
             acc.push(b'\n');
+
+            // Add the full logical command to history, skipping blank inputs.
+            if !Input::new(&acc).is_effectively_empty() {
+                let entry = String::from_utf8_lossy(&acc[..acc.len() - 1]);
+                let _ = rl.add_history_entry(entry.as_ref());
+            }
             return Ok(Some(acc));
         }
     }

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -4,16 +4,6 @@ mod common;
 use common::ShellHarness;
 
 #[test]
-fn repl_shows_prompt_at_startup() {
-    let out = ShellHarness::new().run("");
-    let stdout = out.stdout();
-    assert!(
-        stdout.contains('>') || stdout.contains('❯') || stdout.contains('$'),
-        "expected prompt character in output, got: {stdout:?}"
-    );
-}
-
-#[test]
 fn repl_ignores_empty_lines() {
     ShellHarness::new()
         .run("\n\necho test")


### PR DESCRIPTION
Replaces the BufRead-based input loop in `Shell::run()` with `rustyline`, giving the interactive shell cursor movement, backspace/delete, and in-session history navigation (arrow keys). The shell assumes interactive TTY for its primary mode; non-interactive use is tracked as a separate concern in #126.

`Shell::run_repl(&mut dyn BufRead)` is kept as the future script-mode entry point. The parse-and-execute block is factored into a private `Shell::step()` so both paths share the same logic without duplication. `collect_input_from_reader` (the BufRead-based continuation handler) is unchanged. The rustyline path mirrors its continuation logic — quote and backslash-newline continuation both work correctly in non-TTY mode, as confirmed by the existing multiline integration tests.

Removes `repl_shows_prompt_at_startup` — rustyline suppresses the prompt on piped (non-TTY) stdin, which is correct shell behavior. Updates CLAUDE.md to remove stale `ShellIo`/`MockIo` references and document the new architecture.

Closes #31