### PR TITLE
feat: LineReader trait and script mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ pub struct Cli {
     pub script: Option<PathBuf>,
 
     /// Execute a command string then exit.
-    #[arg(short = 'c', value_name = "COMMAND")]
+    #[arg(short = 'c', value_name = "COMMAND", conflicts_with = "script")]
     pub command: Option<String>,
 }
 
@@ -42,6 +42,12 @@ mod tests {
         let cli = Cli::try_parse_from(["ferrish", "-c", "echo hello"]).unwrap();
         assert_eq!(cli.command.as_deref(), Some("echo hello"));
         assert!(cli.script.is_none());
+    }
+
+    #[test]
+    fn script_and_command_flag_conflict() {
+        let err = Cli::try_parse_from(["ferrish", "script.sh", "-c", "echo hi"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,19 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
 /// An early-stage shell implementation in Rust.
 #[derive(Parser, Debug)]
 #[command(name = "ferrish", version, about)]
-pub struct Cli {}
+pub struct Cli {
+    /// Script file to execute non-interactively.
+    #[arg(value_name = "SCRIPT")]
+    pub script: Option<PathBuf>,
+
+    /// Execute a command string then exit.
+    #[arg(short = 'c', value_name = "COMMAND")]
+    pub command: Option<String>,
+}
 
 #[cfg(test)]
 mod tests {
@@ -18,6 +28,20 @@ mod tests {
     #[test]
     fn bare_invocation_succeeds() {
         assert!(Cli::try_parse_from(["ferrish"]).is_ok());
+    }
+
+    #[test]
+    fn script_arg_parses() {
+        let cli = Cli::try_parse_from(["ferrish", "script.sh"]).unwrap();
+        assert_eq!(cli.script, Some(PathBuf::from("script.sh")));
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn command_flag_parses() {
+        let cli = Cli::try_parse_from(["ferrish", "-c", "echo hello"]).unwrap();
+        assert_eq!(cli.command.as_deref(), Some("echo hello"));
+        assert!(cli.script.is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub mod fs;
 pub mod input;
 /// Lexer: tokenizes raw input into [`lexer::Token`] values.
 pub mod lexer;
+/// Input reader trait and implementations for interactive and script modes.
+pub mod line_reader;
 /// Input parsing: groups tokens into an unresolved pipeline AST.
 pub mod parser;
 /// I/O redirection descriptors produced by the parser.
@@ -39,14 +41,32 @@ pub use shell::Shell;
 
 /// Run the ferrish shell with standard I/O.
 ///
+/// Dispatches based on CLI arguments:
+/// - `ferrish <script>` — executes the script file non-interactively
+/// - `ferrish -c <cmd>` — executes the command string then exits
+/// - `ferrish` — starts the interactive REPL (rustyline handles non-TTY input)
+///
 /// # Example
 /// ```no_run
 /// let result = ferrish::run();
 /// ```
 pub fn run() -> miette::Result<exit::ExitCode> {
     use clap::Parser;
-    match cli::Cli::try_parse() {
-        Ok(_) => Shell::builder().build().run_interactive(),
+    use miette::IntoDiagnostic as _;
+
+    let cli = match cli::Cli::try_parse() {
+        Ok(c) => c,
         Err(e) => e.exit(),
+    };
+
+    let mut shell = Shell::builder().build();
+
+    if let Some(path) = cli.script {
+        let file = std::fs::File::open(&path).into_diagnostic()?;
+        shell.run_script(&mut std::io::BufReader::new(file))
+    } else if let Some(cmd) = cli.command {
+        shell.run_script(&mut std::io::Cursor::new(cmd.into_bytes()))
+    } else {
+        shell.run_interactive()
     }
 }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -23,7 +23,10 @@ pub trait LineReader {
     fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput>;
 
     /// Record a completed logical command in history. No-op by default.
-    fn add_history(&mut self, _entry: &str) {}
+    ///
+    /// `entry` is the raw command bytes with the trailing newline stripped.
+    /// Implementations cast to whatever type their backing store requires.
+    fn add_history(&mut self, _entry: &[u8]) {}
 }
 
 /// Interactive line reader backed by rustyline.
@@ -53,8 +56,9 @@ impl LineReader for InteractiveReader {
         }
     }
 
-    fn add_history(&mut self, entry: &str) {
-        let _ = self.editor.add_history_entry(entry);
+    fn add_history(&mut self, entry: &[u8]) {
+        let s = String::from_utf8_lossy(entry);
+        let _ = self.editor.add_history_entry(s.as_ref());
     }
 }
 

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -1,0 +1,86 @@
+use std::io::BufRead;
+
+use miette::IntoDiagnostic as _;
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+
+/// A single physical line returned by a line-reading source.
+pub enum LineInput {
+    /// A line of bytes, trailing `\n` stripped.
+    Line(Vec<u8>),
+    /// End of input (EOF or Ctrl+D).
+    Eof,
+    /// User interrupted the current input (Ctrl+C); only interactive readers yield this.
+    Interrupted,
+}
+
+/// A source of physical input lines, one per call.
+///
+/// The prompt string passed to [`read_line`] is advisory — interactive
+/// implementations display it; non-interactive ones ignore it.
+pub trait LineReader {
+    /// Read the next physical line, displaying `prompt` if appropriate.
+    fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput>;
+
+    /// Record a completed logical command in history. No-op by default.
+    fn add_history(&mut self, _entry: &str) {}
+}
+
+/// Interactive line reader backed by rustyline.
+///
+/// Displays prompts, supports line editing and history, and yields
+/// [`LineInput::Interrupted`] on Ctrl+C.
+pub struct InteractiveReader {
+    editor: DefaultEditor,
+}
+
+impl InteractiveReader {
+    /// Create a new interactive reader backed by a rustyline editor.
+    pub fn new() -> miette::Result<Self> {
+        Ok(Self {
+            editor: DefaultEditor::new().into_diagnostic()?,
+        })
+    }
+}
+
+impl LineReader for InteractiveReader {
+    fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput> {
+        match self.editor.readline(prompt) {
+            Ok(l) => Ok(LineInput::Line(l.into_bytes())),
+            Err(ReadlineError::Eof) => Ok(LineInput::Eof),
+            Err(ReadlineError::Interrupted) => Ok(LineInput::Interrupted),
+            Err(e) => Err(e).into_diagnostic(),
+        }
+    }
+
+    fn add_history(&mut self, entry: &str) {
+        let _ = self.editor.add_history_entry(entry);
+    }
+}
+
+/// Non-interactive line reader backed by any [`BufRead`] source.
+///
+/// Prompts are suppressed. Never yields [`LineInput::Interrupted`].
+pub struct ScriptReader<'a> {
+    reader: &'a mut dyn BufRead,
+}
+
+impl<'a> ScriptReader<'a> {
+    /// Create a new script reader wrapping `reader`.
+    pub fn new(reader: &'a mut dyn BufRead) -> Self {
+        Self { reader }
+    }
+}
+
+impl LineReader for ScriptReader<'_> {
+    fn read_line(&mut self, _prompt: &str) -> miette::Result<LineInput> {
+        let mut line = Vec::new();
+        if self.reader.read_until(b'\n', &mut line).into_diagnostic()? == 0 {
+            return Ok(LineInput::Eof);
+        }
+        if line.ends_with(b"\n") {
+            line.pop();
+        }
+        Ok(LineInput::Line(line))
+    }
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -126,8 +126,7 @@ impl Shell {
             }
 
             let raw = input.raw_bytes();
-            let entry = String::from_utf8_lossy(raw.strip_suffix(b"\n").unwrap_or(raw));
-            reader.add_history(entry.as_ref());
+            reader.add_history(raw.strip_suffix(b"\n").unwrap_or(raw));
 
             if let Some(exit_code) = self.step(input, &mut err)? {
                 return Ok(exit_code);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -2,32 +2,21 @@ use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 use miette::IntoDiagnostic as _;
-use rustyline::error::ReadlineError;
-use rustyline::DefaultEditor;
 
 use crate::{
     ctx::{ShellConfig, ShellCtx},
     executor,
     exit::ExitCode,
     input::Input,
-    lexer, parser, resolver,
+    lexer,
+    line_reader::{InteractiveReader, LineInput, LineReader, ScriptReader},
+    parser, resolver,
 };
 
-/// A single physical line returned by a line-reading source.
-enum LineInput {
-    /// A line of bytes, trailing `\n` stripped — both sources normalize to this.
-    Line(Vec<u8>),
-    /// End of input (EOF or Ctrl+D).
-    Eof,
-    /// User interrupted the current input (Ctrl+C); only rustyline yields this.
-    Interrupted,
-}
-
-/// Collect one logical input unit from `next_line`, handling quote and
+/// Collect one logical input unit from `reader`, handling quote and
 /// backslash-newline continuation.
 ///
-/// `next_line` is called with the prompt to display before each physical line.
-/// The first call receives `prompt`; subsequent continuation reads receive
+/// The first physical line read uses `prompt`; continuation reads use
 /// `cont_prompt`. Quote continuation is checked before backslash continuation
 /// so that a `\` inside a quoted string is literal and does not trigger line
 /// joining.
@@ -35,7 +24,7 @@ enum LineInput {
 /// Returns `None` on EOF before any input is accumulated, or `Some(Input)`
 /// once a complete logical line is available.
 fn collect_logical_input(
-    mut next_line: impl FnMut(&str) -> miette::Result<LineInput>,
+    reader: &mut dyn LineReader,
     prompt: &str,
     cont_prompt: &str,
 ) -> miette::Result<Option<Input>> {
@@ -45,7 +34,7 @@ fn collect_logical_input(
     loop {
         let current = if acc.is_empty() { prompt } else { cont_prompt };
 
-        let line = match next_line(current)? {
+        let line = match reader.read_line(current)? {
             LineInput::Eof => {
                 if !acc.is_empty() && !acc.ends_with(b"\n") {
                     acc.push(b'\n');
@@ -105,60 +94,26 @@ impl Shell {
     /// (Ctrl+D). Ctrl+C abandons the current input and returns to the prompt.
     /// Diagnostics go to the process's real stderr.
     pub fn run_interactive(&mut self) -> miette::Result<ExitCode> {
-        let mut editor = DefaultEditor::new().into_diagnostic()?;
-        let mut err = std::io::stderr();
-        loop {
-            let input = match collect_logical_input(
-                |prompt| match editor.readline(prompt) {
-                    Ok(l) => Ok(LineInput::Line(l.into_bytes())),
-                    Err(ReadlineError::Eof) => Ok(LineInput::Eof),
-                    Err(ReadlineError::Interrupted) => Ok(LineInput::Interrupted),
-                    Err(e) => Err(e).into_diagnostic(),
-                },
-                &self.ctx.config.prompt,
-                &self.ctx.config.continuation_prompt,
-            )? {
-                None => return Ok(ExitCode::SUCCESS),
-                Some(input) => input,
-            };
-
-            if input.is_effectively_empty() {
-                continue;
-            }
-
-            // Add the complete logical command to history (strip trailing newline).
-            let raw = input.raw_bytes();
-            let entry = String::from_utf8_lossy(raw.strip_suffix(b"\n").unwrap_or(raw));
-            let _ = editor.add_history_entry(entry.as_ref());
-
-            if let Some(exit_code) = self.step(input, &mut err)? {
-                return Ok(exit_code);
-            }
-        }
+        let mut reader = InteractiveReader::new()?;
+        self.run_loop(&mut reader)
     }
 
     /// Run the shell loop from a [`BufRead`] source.
     ///
     /// This is the entry point for script / batch mode; interactive use goes
-    /// through [`Shell::run_interactive`]. Prompts and diagnostics go to the
-    /// process's real stdout/stderr.
-    pub fn run_script(&mut self, reader: &mut dyn BufRead) -> miette::Result<ExitCode> {
-        let mut out = std::io::stdout();
+    /// through [`Shell::run_interactive`]. Prompts are suppressed; diagnostics
+    /// go to the process's real stderr.
+    pub fn run_script(&mut self, source: &mut dyn BufRead) -> miette::Result<ExitCode> {
+        let mut reader = ScriptReader::new(source);
+        self.run_loop(&mut reader)
+    }
+
+    /// Shared REPL loop driven by any [`LineReader`].
+    fn run_loop(&mut self, reader: &mut dyn LineReader) -> miette::Result<ExitCode> {
         let mut err = std::io::stderr();
         loop {
             let input = match collect_logical_input(
-                |prompt| {
-                    out.write_all(prompt.as_bytes()).into_diagnostic()?;
-                    out.flush().into_diagnostic()?;
-                    let mut line = Vec::new();
-                    if reader.read_until(b'\n', &mut line).into_diagnostic()? == 0 {
-                        return Ok(LineInput::Eof);
-                    }
-                    if line.ends_with(b"\n") {
-                        line.pop();
-                    }
-                    Ok(LineInput::Line(line))
-                },
+                reader,
                 &self.ctx.config.prompt,
                 &self.ctx.config.continuation_prompt,
             )? {
@@ -169,6 +124,10 @@ impl Shell {
             if input.is_effectively_empty() {
                 continue;
             }
+
+            let raw = input.raw_bytes();
+            let entry = String::from_utf8_lossy(raw.strip_suffix(b"\n").unwrap_or(raw));
+            reader.add_history(entry.as_ref());
 
             if let Some(exit_code) = self.step(input, &mut err)? {
                 return Ok(exit_code);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -51,9 +51,22 @@ impl ShellHarness {
         self
     }
 
+    /// Spawn ferrish with `path` as a positional CLI argument (script file mode).
+    ///
+    /// The path is resolved relative to the isolated home directory. Use
+    /// [`with_file`](Self::with_file) to pre-create the script before calling
+    /// this method.
+    pub fn run_file(self, path: &str) -> ShellOutput {
+        self.spawn(Some(path), "")
+    }
+
     /// Spawn ferrish, feed `script` as stdin (lines separated by `\n`), and
     /// capture stdout/stderr/exit code. The process exits cleanly on stdin EOF.
     pub fn run(self, script: &str) -> ShellOutput {
+        self.spawn(None, script)
+    }
+
+    fn spawn(self, file_arg: Option<&str>, stdin_script: &str) -> ShellOutput {
         // Canonicalize to the long path form; on Windows tempfile may return
         // short 8.3 paths, but the OS resolves cwd to the long form in `pwd`.
         let home = canonicalize_path(self.temp_dir.path().to_path_buf())
@@ -75,6 +88,10 @@ impl ShellHarness {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .current_dir(&home);
+
+        if let Some(arg) = file_arg {
+            cmd.arg(home.join(arg));
+        }
 
         if self.no_home {
             cmd.env_remove("HOME");
@@ -108,7 +125,7 @@ impl ShellHarness {
 
         let mut child = cmd.spawn().expect("spawn ferrish");
 
-        let stdin_input = script.to_string();
+        let stdin_input = stdin_script.to_string();
         let mut stdin = child.stdin.take().expect("take stdin");
         // Write stdin on a separate thread so the child can keep making progress
         // if it is blocked waiting for input or stdin EOF while the parent waits

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,16 +57,21 @@ impl ShellHarness {
     /// [`with_file`](Self::with_file) to pre-create the script before calling
     /// this method.
     pub fn run_file(self, path: &str) -> ShellOutput {
-        self.spawn(Some(path), "")
+        self.spawn(Some(path), &[], "")
     }
 
     /// Spawn ferrish, feed `script` as stdin (lines separated by `\n`), and
     /// capture stdout/stderr/exit code. The process exits cleanly on stdin EOF.
     pub fn run(self, script: &str) -> ShellOutput {
-        self.spawn(None, script)
+        self.spawn(None, &[], script)
     }
 
-    fn spawn(self, file_arg: Option<&str>, stdin_script: &str) -> ShellOutput {
+    /// Spawn ferrish with `-c <cmd>` (command-string mode).
+    pub fn run_command(self, cmd: &str) -> ShellOutput {
+        self.spawn(None, &["-c", cmd], "")
+    }
+
+    fn spawn(self, file_arg: Option<&str>, raw_args: &[&str], stdin_script: &str) -> ShellOutput {
         // Canonicalize to the long path form; on Windows tempfile may return
         // short 8.3 paths, but the OS resolves cwd to the long form in `pwd`.
         let home = canonicalize_path(self.temp_dir.path().to_path_buf())
@@ -91,6 +96,9 @@ impl ShellHarness {
 
         if let Some(arg) = file_arg {
             cmd.arg(home.join(arg));
+        }
+        for arg in raw_args {
+            cmd.arg(arg);
         }
 
         if self.no_home {

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -1,0 +1,79 @@
+#[allow(dead_code)]
+mod common;
+use common::ShellHarness;
+
+// --- ferrish -c <command> ---
+
+#[test]
+fn command_flag_executes_and_exits() {
+    ShellHarness::new()
+        .run("ferrish -c 'echo hello'")
+        // use the harness's own stdin path; test the flag via a script instead
+        .assert_exit_success();
+}
+
+#[test]
+fn command_flag_echo() {
+    // Invoke the binary directly via ShellHarness::run using -c
+    // ShellHarness::run pipes stdin; for -c we use run_file with a wrapper script.
+    // Easier: nest a shell invocation via echo | ferrish and test run_file separately.
+    ShellHarness::new()
+        .with_file("cmd.sh", "echo hello\n")
+        .run_file("cmd.sh")
+        .assert_stdout_contains("hello")
+        .assert_exit_success();
+}
+
+// --- ferrish <script> ---
+
+#[test]
+fn script_file_single_command() {
+    ShellHarness::new()
+        .with_file("greet.sh", "echo hello\n")
+        .run_file("greet.sh")
+        .assert_stdout_contains("hello")
+        .assert_exit_success();
+}
+
+#[test]
+fn script_file_multiple_commands() {
+    ShellHarness::new()
+        .with_file("multi.sh", "echo first\necho second\n")
+        .run_file("multi.sh")
+        .assert_stdout_contains("first")
+        .assert_stdout_contains("second")
+        .assert_exit_success();
+}
+
+#[test]
+fn script_file_exit_code_propagates() {
+    ShellHarness::new()
+        .with_file("fail.sh", "exit 42\n")
+        .run_file("fail.sh")
+        .assert_exit_code(42);
+}
+
+#[test]
+fn script_file_no_prompt_in_output() {
+    ShellHarness::new()
+        .with_file("greet.sh", "echo hello\n")
+        .run_file("greet.sh")
+        .assert_stdout_not_contains("$ ")
+        .assert_exit_success();
+}
+
+#[test]
+fn script_file_continuation_lines() {
+    ShellHarness::new()
+        .with_file("cont.sh", "echo hello \\\nworld\n")
+        .run_file("cont.sh")
+        .assert_stdout_contains("hello world")
+        .assert_exit_success();
+}
+
+#[test]
+fn script_file_not_found_exits_nonzero() {
+    ShellHarness::new()
+        .run_file("nonexistent_script_xyz.sh")
+        .assert_exit_nonzero();
+}

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -5,23 +5,18 @@ use common::ShellHarness;
 // --- ferrish -c <command> ---
 
 #[test]
-fn command_flag_executes_and_exits() {
+fn command_flag_echo() {
     ShellHarness::new()
-        .run("ferrish -c 'echo hello'")
-        // use the harness's own stdin path; test the flag via a script instead
+        .run_command("echo hello")
+        .assert_stdout_contains("hello")
         .assert_exit_success();
 }
 
 #[test]
-fn command_flag_echo() {
-    // Invoke the binary directly via ShellHarness::run using -c
-    // ShellHarness::run pipes stdin; for -c we use run_file with a wrapper script.
-    // Easier: nest a shell invocation via echo | ferrish and test run_file separately.
+fn command_flag_exit_code_propagates() {
     ShellHarness::new()
-        .with_file("cmd.sh", "echo hello\n")
-        .run_file("cmd.sh")
-        .assert_stdout_contains("hello")
-        .assert_exit_success();
+        .run_command("exit 7")
+        .assert_exit_code(7);
 }
 
 // --- ferrish <script> ---


### PR DESCRIPTION
Implements issues #126 and #128 together, since the `LineReader` trait (#128) is the enabling abstraction for script mode (#126) and has no user-visible impact on its own.

**What changed:**

- `src/line_reader.rs` (new) — `LineReader` trait with `read_line` and a default-noop `add_history`; `InteractiveReader` wraps rustyline, `ScriptReader` wraps any `BufRead`
- `src/shell.rs` — `collect_logical_input` now takes `&mut dyn LineReader`; a shared private `run_loop` drives both `run_interactive` and `run_script`, with history managed via `reader.add_history`
- `src/cli.rs` — adds optional `SCRIPT` positional arg and `-c COMMAND` flag
- `src/lib.rs` — dispatches to `run_script(file)`, `run_script(cursor)`, or `run_interactive()` based on CLI args; no TTY detection — rustyline's non-TTY fallback is preserved for bare invocations
- `tests/common/mod.rs` — `ShellHarness::run_file` for testing CLI-arg invocations
- `tests/script.rs` (new) — integration tests for script file execution, `-c` flag, exit code propagation, continuation lines, prompt suppression, and missing-file error

Closes #126, #128