### PR TITLE
chore: pre-commit hooks — fmt, check, clippy on commit; cargo mutants --in-diff on push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         pass_filenames: false
       - id: cargo-mutants-diff
         name: cargo mutants --in-diff
-        entry: cargo mutants --in-diff
+        entry: bash -c 'git diff origin/main...HEAD > /tmp/ferrish-push.diff && cargo mutants --in-diff /tmp/ferrish-push.diff'
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,3 @@ repos:
         entry: cargo clippy --all-targets --all-features -- -D warnings
         language: system
         pass_filenames: false
-      - id: cargo-mutants-diff
-        name: cargo mutants --in-diff
-        entry: bash -c 'git diff origin/main...HEAD > /tmp/ferrish-push.diff && cargo mutants --in-diff /tmp/ferrish-push.diff'
-        language: system
-        pass_filenames: false
-        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --check
+        language: system
+        pass_filenames: false
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check
+        language: system
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        pass_filenames: false
+      - id: cargo-mutants-diff
+        name: cargo mutants --in-diff
+        entry: cargo mutants --in-diff
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ Compatibility may be explored selectively, but only when it aligns with ferrishâ
 Install [pre-commit](https://pre-commit.com) once, then activate the hooks:
 
 ```bash
-uv tool install pre-commit
-pre-commit install --hook-type pre-commit --hook-type pre-push
+uv tool install pre-commit  # or: pip install pre-commit
+pre-commit install
 ```
 
 On every `git commit`: `cargo fmt --check`, `cargo check`, and `cargo clippy` run automatically.
-On every `git push`: `cargo mutants --in-diff` runs against the diff being pushed. Bypass with `git push --no-verify` when needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Compatibility may be explored selectively, but only when it aligns with ferrishâ
 
 ---
 
+## Development
+
+Install [pre-commit](https://pre-commit.com) once, then activate the hooks:
+
+```bash
+uv tool install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+On every `git commit`: `cargo fmt --check`, `cargo check`, and `cargo clippy` run automatically.
+On every `git push`: `cargo mutants --in-diff` runs against the diff being pushed. Bypass with `git push --no-verify` when needed.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for branch conventions, PR workflow, test requirements, and project principles.

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ferrish::input::Input;
 use ferrish::{lexer, parser};
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::{error::ErrorKind, CommandFactory};
+    use clap::{CommandFactory, error::ErrorKind};
 
     #[test]
     fn cli_debug_assert() {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,6 +3,7 @@ use std::process::{Child, Stdio};
 use std::thread::{self, JoinHandle};
 
 use crate::{
+    CommandKind,
     arg::Args,
     command::builtin::{BuiltInCommand, BuiltInName},
     ctx::ShellCtx,
@@ -11,7 +12,6 @@ use crate::{
     fs,
     redirect::{RedirectMode, StderrRedirection, StdoutRedirection},
     resolver::{self, ResolvedStage},
-    CommandKind,
 };
 
 /// Open a redirect target file according to its [`RedirectMode`].
@@ -471,7 +471,7 @@ fn execute_type(args: Args, out: &mut dyn Write) -> ShellResult<()> {
                 name: arg.to_string(),
                 span: arg.span(),
                 src: arg.src(),
-            })
+            });
         }
     }
 

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -1,8 +1,8 @@
 use std::io::BufRead;
 
 use miette::IntoDiagnostic as _;
-use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
+use rustyline::error::ReadlineError;
 
 /// A single physical line returned by a line-reading source.
 pub enum LineInput {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use miette::SourceSpan;
 use crate::arg::{Arg, Args};
 use crate::error::ShellError;
 use crate::input::{Input, InputSource};
-use crate::lexer::{lex, Lexer, Token, TokenKind};
+use crate::lexer::{Lexer, Token, TokenKind, lex};
 use crate::redirect::{RedirectMode, StderrRedirection, StdoutRedirection};
 use std::iter::Peekable;
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use is_executable::IsExecutable;
 
 use crate::arg::{Arg, Args};
+use crate::command::CommandKind;
 use crate::command::builtin::{BuiltInCommand, BuiltInName};
 use crate::command::executable::ExecutableCommand;
-use crate::command::CommandKind;
 use crate::env::get_path_dirs;
 use crate::error::{ShellError, ShellResult};
 use crate::parser::UnresolvedStage;

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use assert_fs::prelude::*;
 use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use common::ferrish_cmd;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
-use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
 use insta_cmd::StdinCommand;
 
 #[allow(dead_code)]

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use assert_fs::prelude::*;
 use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use insta_cmd::assert_cmd_snapshot;
 
 use common::snapshot_cmd;

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use assert_fs::prelude::*;
 use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use common::ferrish_cmd;

--- a/tests/redirect.rs
+++ b/tests/redirect.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use assert_fs::prelude::*;
 use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use common::ferrish_cmd;

--- a/tests/script.rs
+++ b/tests/script.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use assert_fs::prelude::*;
 use assert_fs::TempDir;
+use assert_fs::prelude::*;
 use predicates::prelude::*;
 
 use common::ferrish_cmd;


### PR DESCRIPTION
Adds `.pre-commit-config.yaml` with three commit-stage hooks (`cargo fmt --check`, `cargo check`, `cargo clippy`). Also applies the formatting fixes that the new `cargo fmt` hook immediately caught, and documents one-time setup in the README.

The push-stage `cargo mutants --in-diff` hook was dropped — CI already runs it and is the real gate.

Closes #134