### PR TITLE
feat: migrate InteractiveReader from rustyline to reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bstr"
@@ -199,16 +211,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.1.1"
+name = "chrono"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -278,15 +306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +323,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +349,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -336,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -365,10 +399,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "difflib"
@@ -381,6 +465,15 @@ name = "doc-comment"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dunce"
@@ -401,12 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,12 +508,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
@@ -460,12 +541,18 @@ dependencies = [
  "miette",
  "predicates",
  "proptest",
- "rustyline",
+ "reedline",
  "soft-canonicalize",
  "strum",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -606,12 +693,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "iana-time-zone"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
- "windows-sys 0.61.2",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -715,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +860,21 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -802,24 +928,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
+name = "mio"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
  "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -827,6 +944,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -869,6 +995,29 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1018,16 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1225,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "reedline"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2066729dce9fecd28d1c6850a159ee68719130f149b22467c362353e16994e90"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools 0.13.0",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "thiserror 2.0.18",
+ "unicase",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,28 +1329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustyline"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
-dependencies = [
- "bitflags",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "home",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "unicode-segmentation",
- "unicode-width 0.1.14",
- "utf8parse",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1336,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1232,6 +1393,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1455,15 @@ checksum = "eaf99d1bbb279dfc59a8642f42fa4b6137935e506c97d1e2e57d282f417f163d"
 dependencies = [
  "dunce",
  "proc-canonicalize",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -1363,7 +1570,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1371,6 +1587,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1392,6 +1619,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1436,6 +1669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1695,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1562,6 +1810,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,18 +1835,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
+name = "windows-result"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "1"
 clap = { version = "4", features = ["derive"] }
 is_executable = "1.0"
 miette = { version = "7", features = ["fancy"] }
-rustyline = "14"
+reedline = "0.47"
 soft-canonicalize = { version = "0.5.4", features = ["dunce"] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use shell::Shell;
 /// Dispatches based on CLI arguments:
 /// - `ferrish <script>` — executes the script file non-interactively
 /// - `ferrish -c <cmd>` — executes the command string then exits
-/// - `ferrish` — starts the interactive REPL (reedline handles line editing)
+/// - `ferrish` — interactive REPL when stdin is a terminal; reads from stdin as a script otherwise
 ///
 /// # Example
 /// ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use shell::Shell;
 /// Dispatches based on CLI arguments:
 /// - `ferrish <script>` — executes the script file non-interactively
 /// - `ferrish -c <cmd>` — executes the command string then exits
-/// - `ferrish` — starts the interactive REPL (rustyline handles non-TTY input)
+/// - `ferrish` — starts the interactive REPL (reedline handles line editing)
 ///
 /// # Example
 /// ```no_run
@@ -66,7 +66,9 @@ pub fn run() -> miette::Result<exit::ExitCode> {
         shell.run_script(&mut std::io::BufReader::new(file))
     } else if let Some(cmd) = cli.command {
         shell.run_script(&mut std::io::Cursor::new(cmd.into_bytes()))
-    } else {
+    } else if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         shell.run_interactive()
+    } else {
+        shell.run_script(&mut std::io::BufReader::new(std::io::stdin()))
     }
 }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -2,11 +2,19 @@ use std::borrow::Cow;
 use std::io::BufRead;
 
 use miette::IntoDiagnostic as _;
-use reedline::{Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal};
+use reedline::{
+    Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal, ValidationResult, Validator,
+};
 
-/// A single physical line returned by a line-reading source.
+use crate::ctx::ShellConfig;
+use crate::lexer::{self, LexerState};
+
+/// A single logical input unit returned by a line-reading source.
+///
+/// Both [`InteractiveReader`] and [`ScriptReader`] accumulate physical lines
+/// internally and only return once a complete shell command is ready.
 pub enum LineInput {
-    /// A line of bytes, trailing `\n` stripped.
+    /// A complete logical command, trailing `\n` included.
     Line(Vec<u8>),
     /// End of input (EOF or Ctrl+D).
     Eof,
@@ -14,19 +22,51 @@ pub enum LineInput {
     Interrupted,
 }
 
-/// A source of physical input lines, one per call.
+/// A source of complete logical shell commands, one per call.
 ///
-/// The prompt string passed to [`read_line`] is advisory — interactive
-/// implementations display it; non-interactive ones ignore it.
+/// Implementations handle their own line accumulation and continuation logic
+/// internally. Callers receive complete, ready-to-parse commands.
 pub trait LineReader {
-    /// Read the next physical line, displaying `prompt` if appropriate.
-    fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput>;
+    /// Read the next complete logical command.
+    fn read_line(&mut self) -> miette::Result<LineInput>;
 }
 
-/// Bridges a `&str` prompt into reedline's [`Prompt`] trait.
-struct ShellPrompt<'a>(&'a str);
+/// Determines whether accumulated input forms a complete shell command.
+///
+/// Implements [`reedline::Validator`] so it can be attached to [`Reedline`] for
+/// interactive multiline support, and is used directly by [`ScriptReader`] for
+/// the same completion checks. Both paths share the same grammar logic through
+/// this struct rather than maintaining parallel implementations.
+///
+/// This is also the intended composition point for future features that need
+/// to understand shell-grammar completeness: the syntax highlighter, the
+/// language server, and other reedline plugins will all delegate here.
+pub struct ShellValidator;
 
-impl Prompt for ShellPrompt<'_> {
+impl Validator for ShellValidator {
+    fn validate(&self, line: &str) -> ValidationResult {
+        let bytes = line.as_bytes();
+        if lexer::needs_continuation(bytes) {
+            return ValidationResult::Incomplete;
+        }
+        // Trailing backslash (outside quotes, since needs_continuation would
+        // have fired for unclosed quotes) means backslash-newline continuation.
+        if bytes.trim_ascii_end().ends_with(b"\\") {
+            return ValidationResult::Incomplete;
+        }
+        ValidationResult::Complete
+    }
+}
+
+/// Stores the prompt strings displayed by [`InteractiveReader`] and implements
+/// reedline's [`Prompt`] trait so both the primary prompt and the continuation
+/// prompt are drawn from the shell's configuration.
+struct ShellPrompt {
+    prompt: String,
+    cont_prompt: String,
+}
+
+impl Prompt for ShellPrompt {
     fn render_prompt_left(&self) -> Cow<'_, str> {
         Cow::Borrowed("")
     }
@@ -36,11 +76,11 @@ impl Prompt for ShellPrompt<'_> {
     }
 
     fn render_prompt_indicator(&self, _: PromptEditMode) -> Cow<'_, str> {
-        Cow::Borrowed(self.0)
+        Cow::Borrowed(&self.prompt)
     }
 
     fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
-        Cow::Borrowed("> ")
+        Cow::Borrowed(&self.cont_prompt)
     }
 
     fn render_prompt_history_search_indicator(&self, _: PromptHistorySearch) -> Cow<'_, str> {
@@ -50,34 +90,46 @@ impl Prompt for ShellPrompt<'_> {
 
 /// Interactive line reader backed by reedline.
 ///
-/// Displays prompts, supports line editing and history, and yields
-/// [`LineInput::Interrupted`] on Ctrl+C. History is managed internally by
-/// reedline and saved automatically on each successful line.
+/// Accumulates physical lines internally via [`ShellValidator`] and returns
+/// complete logical commands. Backslash-newline continuations are joined before
+/// the command is returned. History is managed by reedline and saved
+/// automatically on each successful line.
 ///
 /// This struct is the composition point for reedline plugins — future
 /// `Highlighter`, `Completer`, and `Hinter` implementations wire in here via
-/// builder methods on [`Reedline::create`].
+/// builder methods on [`Reedline::create`]. All such plugins should delegate
+/// into the shared lexer/parser rather than forking grammar logic.
 pub struct InteractiveReader {
     editor: Reedline,
+    prompt: ShellPrompt,
 }
 
 impl InteractiveReader {
-    /// Create a new interactive reader backed by a reedline editor.
-    pub fn new() -> miette::Result<Self> {
-        let editor = Reedline::create();
+    /// Create a new interactive reader using prompts and config from `config`.
+    pub fn new(config: &ShellConfig) -> miette::Result<Self> {
+        let editor = Reedline::create().with_validator(Box::new(ShellValidator));
         // Future plugin hooks (all share the same lexer/parser as the REPL):
         //   .with_highlighter(Box::new(ShellHighlighter))
         //   .with_completer(Box::new(ShellCompleter))
         //   .with_hinter(Box::new(DefaultHinter::default()))
-        Ok(Self { editor })
+        Ok(Self {
+            editor,
+            prompt: ShellPrompt {
+                prompt: config.prompt.clone(),
+                cont_prompt: config.continuation_prompt.clone(),
+            },
+        })
     }
 }
 
 impl LineReader for InteractiveReader {
-    fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput> {
-        let p = ShellPrompt(prompt);
-        match self.editor.read_line(&p).into_diagnostic()? {
-            Signal::Success(s) => Ok(LineInput::Line(s.into_bytes())),
+    fn read_line(&mut self) -> miette::Result<LineInput> {
+        match self.editor.read_line(&self.prompt).into_diagnostic()? {
+            Signal::Success(s) => {
+                let mut bytes = join_backslash_newlines(s.into_bytes());
+                bytes.push(b'\n');
+                Ok(LineInput::Line(bytes))
+            }
             Signal::CtrlC => Ok(LineInput::Interrupted),
             Signal::CtrlD => Ok(LineInput::Eof),
             // HostCommand and ExternalBreak are not issued in the default
@@ -89,7 +141,9 @@ impl LineReader for InteractiveReader {
 
 /// Non-interactive line reader backed by any [`BufRead`] source.
 ///
-/// Prompts are suppressed. Never yields [`LineInput::Interrupted`].
+/// Accumulates physical lines using the same quote-state and continuation
+/// logic as [`ShellValidator`], returning complete logical commands. Prompts
+/// are suppressed. Never yields [`LineInput::Interrupted`].
 pub struct ScriptReader<'a> {
     reader: &'a mut dyn BufRead,
 }
@@ -102,14 +156,62 @@ impl<'a> ScriptReader<'a> {
 }
 
 impl LineReader for ScriptReader<'_> {
-    fn read_line(&mut self, _prompt: &str) -> miette::Result<LineInput> {
-        let mut line = Vec::new();
-        if self.reader.read_until(b'\n', &mut line).into_diagnostic()? == 0 {
-            return Ok(LineInput::Eof);
+    fn read_line(&mut self) -> miette::Result<LineInput> {
+        let mut acc: Vec<u8> = Vec::new();
+        let mut lex_state = LexerState::default();
+
+        loop {
+            let mut line = Vec::new();
+            if self.reader.read_until(b'\n', &mut line).into_diagnostic()? == 0 {
+                if acc.is_empty() {
+                    return Ok(LineInput::Eof);
+                }
+                if !acc.ends_with(b"\n") {
+                    acc.push(b'\n');
+                }
+                return Ok(LineInput::Line(acc));
+            }
+            if line.ends_with(b"\n") {
+                line.pop();
+            }
+
+            lex_state.scan_bytes(&line);
+            lex_state.scan_bytes(b"\n");
+
+            if lex_state.needs_continuation() {
+                acc.extend_from_slice(&line);
+                acc.push(b'\n');
+                continue;
+            }
+
+            if line.ends_with(b"\\") {
+                acc.extend_from_slice(&line[..line.len() - 1]);
+                continue;
+            }
+
+            acc.extend_from_slice(&line);
+            acc.push(b'\n');
+            return Ok(LineInput::Line(acc));
         }
-        if line.ends_with(b"\n") {
-            line.pop();
-        }
-        Ok(LineInput::Line(line))
     }
+}
+
+/// Strip backslash-newline pairs from `bytes`, joining continuation lines.
+///
+/// Operates on the raw buffer returned by reedline after [`ShellValidator`]
+/// has confirmed the input is complete. At that point any remaining `\<LF>`
+/// pairs are outside unclosed quotes (the validator would have returned
+/// `Incomplete` otherwise), so a simple byte scan is correct.
+fn join_backslash_newlines(bytes: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+            i += 2;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    out
 }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -174,6 +174,9 @@ impl LineReader for ScriptReader<'_> {
             if line.ends_with(b"\n") {
                 line.pop();
             }
+            if line.ends_with(b"\r") {
+                line.pop();
+            }
 
             lex_state.scan_bytes(&line);
             lex_state.scan_bytes(b"\n");
@@ -214,4 +217,113 @@ fn join_backslash_newlines(bytes: Vec<u8>) -> Vec<u8> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use reedline::ValidationResult;
+
+    use super::*;
+
+    // --- ShellValidator ---
+
+    #[test]
+    fn validator_complete_for_simple_command() {
+        assert!(matches!(
+            ShellValidator.validate("echo hello"),
+            ValidationResult::Complete
+        ));
+    }
+
+    #[test]
+    fn validator_incomplete_for_unclosed_single_quote() {
+        assert!(matches!(
+            ShellValidator.validate("echo 'hello"),
+            ValidationResult::Incomplete
+        ));
+    }
+
+    #[test]
+    fn validator_incomplete_for_unclosed_double_quote() {
+        assert!(matches!(
+            ShellValidator.validate("echo \"hello"),
+            ValidationResult::Incomplete
+        ));
+    }
+
+    #[test]
+    fn validator_complete_after_multiline_single_quote() {
+        assert!(matches!(
+            ShellValidator.validate("echo 'hello\nworld'"),
+            ValidationResult::Complete
+        ));
+    }
+
+    #[test]
+    fn validator_incomplete_for_trailing_backslash() {
+        assert!(matches!(
+            ShellValidator.validate("echo foo\\"),
+            ValidationResult::Incomplete
+        ));
+    }
+
+    #[test]
+    fn validator_complete_after_backslash_continuation() {
+        assert!(matches!(
+            ShellValidator.validate("echo foo\\\nbar"),
+            ValidationResult::Complete
+        ));
+    }
+
+    #[test]
+    fn validator_incomplete_trailing_backslash_with_trailing_spaces() {
+        // trim_ascii_end strips trailing spaces before the backslash check so that
+        // trailing whitespace after `\` doesn't mask a continuation.
+        assert!(matches!(
+            ShellValidator.validate("echo foo\\   "),
+            ValidationResult::Incomplete
+        ));
+    }
+
+    // --- join_backslash_newlines ---
+
+    #[test]
+    fn join_removes_backslash_newline_pair() {
+        assert_eq!(
+            join_backslash_newlines(b"echo foo\\\nbar\n".to_vec()),
+            b"echo foobar\n"
+        );
+    }
+
+    #[test]
+    fn join_no_op_without_continuation() {
+        assert_eq!(
+            join_backslash_newlines(b"echo hello\n".to_vec()),
+            b"echo hello\n"
+        );
+    }
+
+    #[test]
+    fn join_multiple_continuations() {
+        assert_eq!(
+            join_backslash_newlines(b"echo a\\\nb\\\nc\n".to_vec()),
+            b"echo abc\n"
+        );
+    }
+
+    #[test]
+    fn join_preserves_backslash_not_before_newline() {
+        assert_eq!(
+            join_backslash_newlines(b"echo foo\\bar\n".to_vec()),
+            b"echo foo\\bar\n"
+        );
+    }
+
+    #[test]
+    fn join_preserves_trailing_backslash_at_end_of_buffer() {
+        assert_eq!(
+            join_backslash_newlines(b"echo foo\\".to_vec()),
+            b"echo foo\\"
+        );
+    }
 }

--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -1,8 +1,8 @@
+use std::borrow::Cow;
 use std::io::BufRead;
 
 use miette::IntoDiagnostic as _;
-use rustyline::DefaultEditor;
-use rustyline::error::ReadlineError;
+use reedline::{Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal};
 
 /// A single physical line returned by a line-reading source.
 pub enum LineInput {
@@ -21,44 +21,69 @@ pub enum LineInput {
 pub trait LineReader {
     /// Read the next physical line, displaying `prompt` if appropriate.
     fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput>;
-
-    /// Record a completed logical command in history. No-op by default.
-    ///
-    /// `entry` is the raw command bytes with the trailing newline stripped.
-    /// Implementations cast to whatever type their backing store requires.
-    fn add_history(&mut self, _entry: &[u8]) {}
 }
 
-/// Interactive line reader backed by rustyline.
+/// Bridges a `&str` prompt into reedline's [`Prompt`] trait.
+struct ShellPrompt<'a>(&'a str);
+
+impl Prompt for ShellPrompt<'_> {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_right(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_indicator(&self, _: PromptEditMode) -> Cow<'_, str> {
+        Cow::Borrowed(self.0)
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
+        Cow::Borrowed("> ")
+    }
+
+    fn render_prompt_history_search_indicator(&self, _: PromptHistorySearch) -> Cow<'_, str> {
+        Cow::Borrowed("search: ")
+    }
+}
+
+/// Interactive line reader backed by reedline.
 ///
 /// Displays prompts, supports line editing and history, and yields
-/// [`LineInput::Interrupted`] on Ctrl+C.
+/// [`LineInput::Interrupted`] on Ctrl+C. History is managed internally by
+/// reedline and saved automatically on each successful line.
+///
+/// This struct is the composition point for reedline plugins — future
+/// `Highlighter`, `Completer`, and `Hinter` implementations wire in here via
+/// builder methods on [`Reedline::create`].
 pub struct InteractiveReader {
-    editor: DefaultEditor,
+    editor: Reedline,
 }
 
 impl InteractiveReader {
-    /// Create a new interactive reader backed by a rustyline editor.
+    /// Create a new interactive reader backed by a reedline editor.
     pub fn new() -> miette::Result<Self> {
-        Ok(Self {
-            editor: DefaultEditor::new().into_diagnostic()?,
-        })
+        let editor = Reedline::create();
+        // Future plugin hooks (all share the same lexer/parser as the REPL):
+        //   .with_highlighter(Box::new(ShellHighlighter))
+        //   .with_completer(Box::new(ShellCompleter))
+        //   .with_hinter(Box::new(DefaultHinter::default()))
+        Ok(Self { editor })
     }
 }
 
 impl LineReader for InteractiveReader {
     fn read_line(&mut self, prompt: &str) -> miette::Result<LineInput> {
-        match self.editor.readline(prompt) {
-            Ok(l) => Ok(LineInput::Line(l.into_bytes())),
-            Err(ReadlineError::Eof) => Ok(LineInput::Eof),
-            Err(ReadlineError::Interrupted) => Ok(LineInput::Interrupted),
-            Err(e) => Err(e).into_diagnostic(),
+        let p = ShellPrompt(prompt);
+        match self.editor.read_line(&p).into_diagnostic()? {
+            Signal::Success(s) => Ok(LineInput::Line(s.into_bytes())),
+            Signal::CtrlC => Ok(LineInput::Interrupted),
+            Signal::CtrlD => Ok(LineInput::Eof),
+            // HostCommand and ExternalBreak are not issued in the default
+            // configuration; treat them as interrupts so the REPL continues.
+            _ => Ok(LineInput::Interrupted),
         }
-    }
-
-    fn add_history(&mut self, entry: &[u8]) {
-        let s = String::from_utf8_lossy(entry);
-        let _ = self.editor.add_history_entry(s.as_ref());
     }
 }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -88,7 +88,7 @@ impl Shell {
         ShellBuilder::default()
     }
 
-    /// Run the interactive REPL using rustyline for line editing.
+    /// Run the interactive REPL using reedline for line editing.
     ///
     /// Reads from the terminal until `exit` is called or the user signals EOF
     /// (Ctrl+D). Ctrl+C abandons the current input and returns to the prompt.
@@ -124,9 +124,6 @@ impl Shell {
             if input.is_effectively_empty() {
                 continue;
             }
-
-            let raw = input.raw_bytes();
-            reader.add_history(raw.strip_suffix(b"\n").unwrap_or(raw));
 
             if let Some(exit_code) = self.step(input, &mut err)? {
                 return Ok(exit_code);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -8,74 +8,9 @@ use crate::{
     executor,
     exit::ExitCode,
     input::Input,
-    lexer,
     line_reader::{InteractiveReader, LineInput, LineReader, ScriptReader},
     parser, resolver,
 };
-
-/// Collect one logical input unit from `reader`, handling quote and
-/// backslash-newline continuation.
-///
-/// The first physical line read uses `prompt`; continuation reads use
-/// `cont_prompt`. Quote continuation is checked before backslash continuation
-/// so that a `\` inside a quoted string is literal and does not trigger line
-/// joining.
-///
-/// Returns `None` on EOF before any input is accumulated, or `Some(Input)`
-/// once a complete logical line is available.
-fn collect_logical_input(
-    reader: &mut dyn LineReader,
-    prompt: &str,
-    cont_prompt: &str,
-) -> miette::Result<Option<Input>> {
-    let mut acc: Vec<u8> = Vec::new();
-    let mut lex_state = lexer::LexerState::default();
-
-    loop {
-        let current = if acc.is_empty() { prompt } else { cont_prompt };
-
-        let line = match reader.read_line(current)? {
-            LineInput::Eof => {
-                if !acc.is_empty() && !acc.ends_with(b"\n") {
-                    acc.push(b'\n');
-                }
-                return Ok(if acc.is_empty() {
-                    None
-                } else {
-                    Some(Input::from_vec(acc))
-                });
-            }
-            LineInput::Interrupted => {
-                acc.clear();
-                lex_state = lexer::LexerState::default();
-                continue;
-            }
-            LineInput::Line(l) => l,
-        };
-
-        // Scan new bytes into the quote-state tracker — O(n) for this line only,
-        // not the full accumulation. See LexerState::scan_bytes in lexer.rs for
-        // the escape and quote rules.
-        lex_state.scan_bytes(&line);
-        lex_state.scan_bytes(b"\n");
-
-        if lex_state.needs_continuation() {
-            acc.extend_from_slice(&line);
-            acc.push(b'\n');
-            continue;
-        }
-
-        // Backslash-newline: join this line to the next, stripping the `\`.
-        if line.ends_with(b"\\") {
-            acc.extend_from_slice(&line[..line.len() - 1]);
-            continue;
-        }
-
-        acc.extend_from_slice(&line);
-        acc.push(b'\n');
-        return Ok(Some(Input::from_vec(acc)));
-    }
-}
 
 /// The ferrish shell REPL.
 pub struct Shell {
@@ -94,7 +29,7 @@ impl Shell {
     /// (Ctrl+D). Ctrl+C abandons the current input and returns to the prompt.
     /// Diagnostics go to the process's real stderr.
     pub fn run_interactive(&mut self) -> miette::Result<ExitCode> {
-        let mut reader = InteractiveReader::new()?;
+        let mut reader = InteractiveReader::new(&self.ctx.config)?;
         self.run_loop(&mut reader)
     }
 
@@ -109,24 +44,24 @@ impl Shell {
     }
 
     /// Shared REPL loop driven by any [`LineReader`].
+    ///
+    /// Each call to [`LineReader::read_line`] returns a complete logical
+    /// command — accumulation and continuation are handled inside the reader.
     fn run_loop(&mut self, reader: &mut dyn LineReader) -> miette::Result<ExitCode> {
         let mut err = std::io::stderr();
         loop {
-            let input = match collect_logical_input(
-                reader,
-                &self.ctx.config.prompt,
-                &self.ctx.config.continuation_prompt,
-            )? {
-                None => return Ok(ExitCode::SUCCESS),
-                Some(input) => input,
-            };
-
-            if input.is_effectively_empty() {
-                continue;
-            }
-
-            if let Some(exit_code) = self.step(input, &mut err)? {
-                return Ok(exit_code);
+            match reader.read_line()? {
+                LineInput::Eof => return Ok(ExitCode::SUCCESS),
+                LineInput::Interrupted => continue,
+                LineInput::Line(bytes) => {
+                    let input = Input::from_vec(bytes);
+                    if input.is_effectively_empty() {
+                        continue;
+                    }
+                    if let Some(exit_code) = self.step(input, &mut err)? {
+                        return Ok(exit_code);
+                    }
+                }
             }
         }
     }

--- a/tests/builtin.rs
+++ b/tests/builtin.rs
@@ -322,8 +322,8 @@ fn cat_is_a_builtin() {
 
 #[test]
 fn cat_reads_file_arg() {
-    use assert_fs::prelude::*;
     use assert_fs::TempDir;
+    use assert_fs::prelude::*;
     let temp = TempDir::new().unwrap();
     temp.child("hello.txt")
         .write_str("hello from file\n")


### PR DESCRIPTION
Replaces rustyline's `DefaultEditor` with reedline's `Reedline`, isolated entirely to `src/line_reader.rs` and `Cargo.toml`. The `LineReader` trait is trimmed to just `read_line` (no prompt param, no `add_history`) — reedline manages history internally and prompts are construction-time config.

A `ShellValidator` implementing `reedline::Validator` is introduced as the shared input-completion logic for both modes: reedline uses it to drive native multiline accumulation in interactive mode; `ScriptReader` uses the same `LexerState` logic for script accumulation. `collect_logical_input` is removed — `run_loop` simplifies to a straight `read_line` → `step` loop. `ShellPrompt` stores both the primary and continuation prompts from `ShellConfig` so `render_prompt_multiline_indicator` returns the right string.

Bare non-TTY invocations route through `run_script(stdin)` rather than failing, matching standard shell behavior.

Closes #137
Closes #144