### PR TITLE
feat: history persistence, up/down navigation, and reverse search

### DIFF
--- a/src/line_reader.rs
+++ b/src/line_reader.rs
@@ -3,7 +3,8 @@ use std::io::BufRead;
 
 use miette::IntoDiagnostic as _;
 use reedline::{
-    Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal, ValidationResult, Validator,
+    FileBackedHistory, Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal,
+    ValidationResult, Validator,
 };
 
 use crate::ctx::ShellConfig;
@@ -107,7 +108,12 @@ pub struct InteractiveReader {
 impl InteractiveReader {
     /// Create a new interactive reader using prompts and config from `config`.
     pub fn new(config: &ShellConfig) -> miette::Result<Self> {
-        let editor = Reedline::create().with_validator(Box::new(ShellValidator));
+        let mut editor = Reedline::create().with_validator(Box::new(ShellValidator));
+        if let Some(ref path) = config.history_path {
+            let history =
+                FileBackedHistory::with_file(config.max_history, path.clone()).into_diagnostic()?;
+            editor = editor.with_history(Box::new(history));
+        }
         // Future plugin hooks (all share the same lexer/parser as the REPL):
         //   .with_highlighter(Box::new(ShellHighlighter))
         //   .with_completer(Box::new(ShellCompleter))

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -125,11 +125,14 @@ impl ShellBuilder {
     /// Build the [`Shell`].
     pub fn build(self) -> Shell {
         let base = ShellCtx::from_env();
-        let ctx = ShellCtx::with_config(
-            self.home_dir.or(base.home_dir),
-            self.cwd.unwrap_or(base.cwd),
-            self.config.unwrap_or_default(),
-        );
+        let home = self.home_dir.or(base.home_dir);
+        let mut config = self.config.unwrap_or_default();
+        if config.history_path.is_none()
+            && let Some(ref h) = home
+        {
+            config.history_path = Some(h.join(".ferrish_history"));
+        }
+        let ctx = ShellCtx::with_config(home, self.cwd.unwrap_or(base.cwd), config);
         Shell { ctx }
     }
 }
@@ -165,5 +168,31 @@ mod tests {
             .with_prompt("OVERRIDE> ".to_string())
             .build();
         assert_eq!(shell.ctx.config.prompt, "OVERRIDE> ");
+    }
+
+    #[test]
+    fn build_derives_history_path_from_home_dir() {
+        use std::path::PathBuf;
+        let home = PathBuf::from("/tmp/test-home");
+        let shell = Shell::builder().with_home_dir(home.clone()).build();
+        assert_eq!(
+            shell.ctx.config.history_path,
+            Some(home.join(".ferrish_history"))
+        );
+    }
+
+    #[test]
+    fn explicit_history_path_not_overridden() {
+        use std::path::PathBuf;
+        let custom = PathBuf::from("/tmp/my_history");
+        let config = ShellConfig {
+            history_path: Some(custom.clone()),
+            ..Default::default()
+        };
+        let shell = Shell::builder()
+            .with_home_dir(PathBuf::from("/tmp/home"))
+            .with_config(config)
+            .build();
+        assert_eq!(shell.ctx.config.history_path, Some(custom));
     }
 }


### PR DESCRIPTION
Wire `FileBackedHistory` into `InteractiveReader::new()` using the path and size limit from `ShellConfig`. The default history path (`~/.ferrish_history`) is derived from the user's home directory in `ShellBuilder::build()` and can be overridden via `ShellConfig::history_path`. Up/down arrow navigation (#37) and Ctrl+R reverse search (#38) are built-in to reedline once a file-backed history is present — no additional code is required for either.

`history -r`/`-w` subcommands from #39's acceptance criteria are not included here — those belong to the `history` builtin (#36) and may be reconsidered when that issue is addressed.

Closes #37
Closes #38